### PR TITLE
Do not create non-existing static file nodes from deferred glob matches

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Effectively make watching recursive when a directory is added that is known in the workflow.
 - The function `amend()` now always returns `True` when the RPC client is a dummy.
   This fixes early exits from scripts that used `amend()` when they are called manually.
-- Prevent the `Cannot watch non-existing directory` error by insisting that deferred glob matches
-  must exist before they are included as static files in the graph.
+- Prevent the `Cannot watch non-existing directory` error by ensuring that deferred glob matches
+  exist before they are included as static files in the graph.
 
 
 ## [1.2.4] - 2024-05-27

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Effectively make watching recursive when a directory is added that is known in the workflow.
 - The function `amend()` now always returns `True` when the RPC client is a dummy.
   This fixes early exits from scripts that used `amend()` when they are called manually.
+- Prevent the `Cannot watch non-existing directory` error by insisting that deferred glob matches
+  must exist before they are included as static files in the graph.
 
 
 ## [1.2.4] - 2024-05-27

--- a/stepup/core/workflow.py
+++ b/stepup/core/workflow.py
@@ -28,6 +28,7 @@ from collections.abc import Collection
 from typing import Self, cast
 
 import attrs
+from path import Path
 
 from .assoc import Assoc, many_to_one
 from .cascade import Cascade, Node, get_kind
@@ -38,7 +39,7 @@ from .hash import ExtendedStepHash, FileHash
 from .job import SetPoolJob
 from .nglob import NGlobMulti
 from .step import Mandatory, Step, StepState
-from .utils import lookupdict, myparent
+from .utils import check_inp_path, lookupdict, myparent
 
 __all__ = ("Workflow",)
 
@@ -316,6 +317,9 @@ class Workflow(Cascade):
                     self.supply_parent(file)
                     file.set_state(self, FileState.PENDING)
                 else:
+                    message = check_inp_path(Path(path))
+                    if message is not None:
+                        raise ValueError(f"{message}: {path}")
                     dg.ngm.extend([path])
                     self.declare_static(dg.key, [path])
                     available = True

--- a/tests/cases/error_deferred_nonexisting/expected_stdout.txt
+++ b/tests/cases/error_deferred_nonexisting/expected_stdout.txt
@@ -1,28 +1,18 @@
   DIRECTOR │ Launched worker 0
      PHASE │ run
      START │ ./plan.py
-   SUCCESS │ ./plan.py
-      FAIL │ cat static/foo/bar/README.md
+      FAIL │ ./plan.py
 ────────────────────────────────── Step info ───────────────────────────────────
-Command               cat static/foo/bar/README.md
-──────────────────────────────── Invalid inputs ────────────────────────────────
-STATIC Path does not exist: static/foo/bar/README.md
+Command               ./plan.py
+Return code           1
+──────────────────────────────── Standard error ────────────────────────────────
+(stripped)
 ────────────────────────────────────────────────────────────────────────────────
    WARNING │ 1 step(s) failed, see error messages above
+   WARNING │ Scheduler is put on hold. Not reporting pending steps.
    WARNING │ Skipping cleanup due to incomplete build.
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
+   WARNING │ Dissolving the workflow due to an exceptions while the graph was being changed.
+     PHASE │ watch
   DIRECTOR │ Stopping workers.
-     ERROR │ The director raised an exception.
-────────────────────────────────── Traceback ───────────────────────────────────
-Traceback (most recent call last):
-  File "${PWD}/stepup/core/director.py", line ---, in async_main
-    await serve(
-  File "${PWD}/stepup/core/director.py", line ---, in serve
-    await asyncio.gather(watcher_loop, runner_loop, rpc_director)
-  File "${PWD}/stepup/core/watcher.py", line ---, in loop
-    await dir_loop
-  File "${PWD}/stepup/core/watcher.py", line ---, in dir_loop
-    raise FileNotFoundError(f"Cannot watch non-existing directory: {path}")
-FileNotFoundError: Cannot watch non-existing directory: static/
-────────────────────────────────────────────────────────────────────────────────
   DIRECTOR │ See you!

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1381,6 +1381,9 @@ def test_deferred_glob_basic(wfp, path_tmp):
         assert wfp.get_file("file:tail_1.txt").get_state(wfp) == FileState.STATIC
         assert "tail_1.txt" in dg.ngm.files()
 
+    with pytest.raises(ValueError):
+        wfp.define_step(plan_key, "cat head_2.txt", inp_paths=["head_2.txt"])
+
 
 def test_deferred_glob_clean(wfp, path_tmp):
     plan_key = "step:./plan.py"


### PR DESCRIPTION
bugfix ...

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a bug where non-existing static file nodes were being created from deferred glob matches. It adds validation to ensure input paths exist before including them as static files and updates the tests accordingly. The changelog has also been updated to reflect this fix.

* **Bug Fixes**:
    - Prevented the creation of non-existing static file nodes from deferred glob matches.
* **Enhancements**:
    - Added validation to check if input paths exist before including them as static files in the workflow.
* **Documentation**:
    - Updated changelog to include the fix for the 'Cannot watch non-existing directory' error.
* **Tests**:
    - Modified tests to create necessary files and directories before defining steps to ensure deferred glob matches are valid.

<!-- Generated by sourcery-ai[bot]: end summary -->