### PR TITLE
Do not create non-existing static file nodes from deferred glob matches

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Effectively make watching recursive when a directory is added that is known in the workflow.
 - The function `amend()` now always returns `True` when the RPC client is a dummy.
   This fixes early exits from scripts that used `amend()` when they are called manually.
-
+- Prevent the `Cannot watch non-existing directory` error by ensuring that deferred glob matches
+  exist before they are included as static files in the graph.
 
 ## [1.2.4] - 2024-05-27
 

--- a/stepup/core/director.py
+++ b/stepup/core/director.py
@@ -304,9 +304,33 @@ class DirectorHandler:
 
     @allow_rpc
     def defer(self, creator_key: str, patterns: list[str]):
-        """Register a deferred glob."""
+        """Register a deferred glob.
+
+        Returns
+        -------
+        to_check
+            A list of paths to check and make static if valid.
+        """
         with self._dissolve_if_graph_changed():
-            self._workflow.defer_glob(creator_key, patterns)
+            return self._workflow.defer_glob(creator_key, patterns)
+
+    @allow_rpc
+    def filter_deferred(self, paths: list[str]) -> list[str]:
+        """Test all paths against deferred globs and return matches.
+
+        Returns
+        -------
+        to_check
+            A list of paths whose existence and validity needs to be checked.
+        """
+        with self._dissolve_if_graph_changed():
+            return self._workflow.filter_deferred(paths)
+
+    @allow_rpc
+    def confirm_deferred(self, paths: list[str]):
+        """Mark missing files as static because they were found to be present."""
+        with self._dissolve_if_graph_changed():
+            self._workflow.confirm_deferred(paths)
 
     @allow_rpc
     def step(

--- a/stepup/core/runner.py
+++ b/stepup/core/runner.py
@@ -272,27 +272,28 @@ async def report_completion(workflow: Workflow, scheduler: Scheduler, reporter: 
             if step.workdir != ".":
                 lines.append(f"Working directory     {step.workdir}")
 
-            static_paths = step.get_static_paths(workflow, state=True)
             prefix = "Declares"
-            for path, state in static_paths:
-                lines.append(f"{prefix}      {state.name:>8s}  {path}")
+            for path in step.get_static_paths(workflow):
+                lines.append(f"{prefix}        STATIC  {path}")
                 prefix = "        "
 
-            inp_paths = step.get_inp_paths(workflow, state=True, orphan=True)
+            prefix = "Declares"
+            for path in step.get_missing_paths(workflow):
+                lines.append(f"{prefix}       MISSING  {path}")
+                prefix = "        "
+
             prefix = "Inputs"
-            for path, state, orphan in inp_paths:
+            for path, state, orphan in step.get_inp_paths(workflow, state=True, orphan=True):
                 path_fmt = f"({path})" if orphan else path
                 lines.append(f"{prefix}      {state.name:>8s}  {path_fmt}")
                 prefix = "      "
 
-            out_paths = step.get_out_paths(workflow, state=True)
             prefix = "Outputs"
-            for path, state in out_paths:
+            for path, state in step.get_out_paths(workflow, state=True):
                 lines.append(f"{prefix}     {state.name:>8s}  {path}")
                 prefix = "       "
 
-            vol_paths = step.get_vol_paths(workflow)
-            for path in vol_paths:
+            for path in step.get_vol_paths(workflow):
                 lines.append(f"{prefix}     VOLATILE  {path}")
                 prefix = "       "
 

--- a/stepup/core/step.py
+++ b/stepup/core/step.py
@@ -467,11 +467,31 @@ class Step(Node):
         return self._get_paths(workflow, file_keys, False, file_hash, False, filter_states)
 
     def get_static_paths(self, workflow: "Workflow", *, file_hash=False) -> list:
+        """Return a list of STATIC paths created by this step.
+
+        Patterns
+        --------
+        workflow
+            The workflow in which the step is defined.
+        file_hash
+            If True, a list with path and file_hash tuples is returned.
+            If False, just a list of paths is returned.
+        """
         file_keys = workflow.get_products(self.key, kind="file")
         filter_states = (FileState.STATIC,)
         return self._get_paths(workflow, file_keys, False, file_hash, False, filter_states)
 
     def get_missing_paths(self, workflow: "Workflow", *, file_hash=False) -> list:
+        """Return a list of MISSING paths created by this step.
+
+        Patterns
+        --------
+        workflow
+            The workflow in which the step is defined.
+        file_hash
+            If True, a list with path and file_hash tuples is returned.
+            If False, just a list of paths is returned.
+        """
         file_keys = workflow.get_products(self.key, kind="file")
         filter_states = (FileState.MISSING,)
         return self._get_paths(workflow, file_keys, False, file_hash, False, filter_states)

--- a/tests/cases/deferred_glob2/expected_graph_01.txt
+++ b/tests/cases/deferred_glob2/expected_graph_01.txt
@@ -37,6 +37,27 @@ dg:'static/**'
              creates   file:static/sub/
              creates   file:static/sub/foo.txt
 
+file:static/
+                path = static/
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:./
+            supplies   file:static/sub/
+
+file:static/sub/
+                path = static/sub/
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:static/
+            supplies   file:static/sub/foo.txt
+
+file:static/sub/foo.txt
+                path = static/sub/foo.txt
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:static/sub/
+            supplies   step:cp -aT static/sub/foo.txt copy.txt
+
 step:cp -aT static/sub/foo.txt copy.txt
              workdir = ./
              command = cp -aT static/sub/foo.txt copy.txt
@@ -46,27 +67,6 @@ step:cp -aT static/sub/foo.txt copy.txt
             consumes   file:static/sub/foo.txt
              creates   file:copy.txt
             supplies   file:copy.txt
-
-file:static/sub/foo.txt
-                path = static/sub/foo.txt
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:static/sub/
-            supplies   step:cp -aT static/sub/foo.txt copy.txt
-
-file:static/sub/
-                path = static/sub/
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:static/
-            supplies   file:static/sub/foo.txt
-
-file:static/
-                path = static/
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:./
-            supplies   file:static/sub/
 
 file:copy.txt
                 path = copy.txt

--- a/tests/cases/deferred_nonexisting_dir/expected_graph_01.txt
+++ b/tests/cases/deferred_nonexisting_dir/expected_graph_01.txt
@@ -36,6 +36,20 @@ dg:'sub/**'
              creates   file:sub/
              creates   file:sub/message.txt
 
+file:sub/
+                path = sub/
+               state = STATIC
+          created by   dg:'sub/**'
+            consumes   file:./
+            supplies   file:sub/message.txt
+
+file:sub/message.txt
+                path = sub/message.txt
+               state = STATIC
+          created by   dg:'sub/**'
+            consumes   file:sub/
+            supplies   step:cp -aT sub/message.txt message.txt
+
 step:cp -aT sub/message.txt message.txt
              workdir = ./
              command = cp -aT sub/message.txt message.txt
@@ -45,20 +59,6 @@ step:cp -aT sub/message.txt message.txt
             consumes   file:sub/message.txt
              creates   file:message.txt
             supplies   file:message.txt
-
-file:sub/message.txt
-                path = sub/message.txt
-               state = STATIC
-          created by   dg:'sub/**'
-            consumes   file:sub/
-            supplies   step:cp -aT sub/message.txt message.txt
-
-file:sub/
-                path = sub/
-               state = STATIC
-          created by   dg:'sub/**'
-            consumes   file:./
-            supplies   file:sub/message.txt
 
 file:message.txt
                 path = message.txt

--- a/tests/cases/deferred_nonexisting_dir/expected_graph_02.txt
+++ b/tests/cases/deferred_nonexisting_dir/expected_graph_02.txt
@@ -36,6 +36,20 @@ dg:'sub/**'
              creates   file:sub/
              creates   file:sub/message.txt
 
+file:sub/
+                path = sub/
+               state = MISSING
+          created by   dg:'sub/**'
+            consumes   file:./
+            supplies   file:sub/message.txt
+
+file:sub/message.txt
+                path = sub/message.txt
+               state = MISSING
+          created by   dg:'sub/**'
+            consumes   file:sub/
+            supplies   step:cp -aT sub/message.txt message.txt
+
 step:cp -aT sub/message.txt message.txt
              workdir = ./
              command = cp -aT sub/message.txt message.txt
@@ -45,20 +59,6 @@ step:cp -aT sub/message.txt message.txt
             consumes   file:sub/message.txt
              creates   file:message.txt
             supplies   file:message.txt
-
-file:sub/message.txt
-                path = sub/message.txt
-               state = MISSING
-          created by   dg:'sub/**'
-            consumes   file:sub/
-            supplies   step:cp -aT sub/message.txt message.txt
-
-file:sub/
-                path = sub/
-               state = MISSING
-          created by   dg:'sub/**'
-            consumes   file:./
-            supplies   file:sub/message.txt
 
 file:message.txt
                 path = message.txt

--- a/tests/cases/deferred_nonexisting_dir/expected_graph_03.txt
+++ b/tests/cases/deferred_nonexisting_dir/expected_graph_03.txt
@@ -36,6 +36,20 @@ dg:'sub/**'
              creates   file:sub/
              creates   file:sub/message.txt
 
+file:sub/
+                path = sub/
+               state = STATIC
+          created by   dg:'sub/**'
+            consumes   file:./
+            supplies   file:sub/message.txt
+
+file:sub/message.txt
+                path = sub/message.txt
+               state = STATIC
+          created by   dg:'sub/**'
+            consumes   file:sub/
+            supplies   step:cp -aT sub/message.txt message.txt
+
 step:cp -aT sub/message.txt message.txt
              workdir = ./
              command = cp -aT sub/message.txt message.txt
@@ -45,20 +59,6 @@ step:cp -aT sub/message.txt message.txt
             consumes   file:sub/message.txt
              creates   file:message.txt
             supplies   file:message.txt
-
-file:sub/message.txt
-                path = sub/message.txt
-               state = STATIC
-          created by   dg:'sub/**'
-            consumes   file:sub/
-            supplies   step:cp -aT sub/message.txt message.txt
-
-file:sub/
-                path = sub/
-               state = STATIC
-          created by   dg:'sub/**'
-            consumes   file:./
-            supplies   file:sub/message.txt
 
 file:message.txt
                 path = message.txt

--- a/tests/cases/deferred_subdir/expected_graph.txt
+++ b/tests/cases/deferred_subdir/expected_graph.txt
@@ -62,6 +62,13 @@ dg:'sub/u*.txt'
           created by   step:./plan.py  # wd=sub/
              creates   file:sub/used.txt
 
+file:sub/used.txt
+                path = sub/used.txt
+               state = STATIC
+          created by   dg:'sub/u*.txt'
+            consumes   file:sub/
+            supplies   step:cp -aT used.txt copy.txt  # wd=sub/
+
 step:cp -aT used.txt copy.txt  # wd=sub/
              workdir = sub/
              command = cp -aT used.txt copy.txt
@@ -71,13 +78,6 @@ step:cp -aT used.txt copy.txt  # wd=sub/
             consumes   file:sub/used.txt
              creates   file:sub/copy.txt
             supplies   file:sub/copy.txt
-
-file:sub/used.txt
-                path = sub/used.txt
-               state = STATIC
-          created by   dg:'sub/u*.txt'
-            consumes   file:sub/
-            supplies   step:cp -aT used.txt copy.txt  # wd=sub/
 
 file:sub/copy.txt
                 path = sub/copy.txt

--- a/tests/cases/error_deferred_nonexisting/expected_stdout.txt
+++ b/tests/cases/error_deferred_nonexisting/expected_stdout.txt
@@ -1,28 +1,16 @@
   DIRECTOR │ Launched worker 0
      PHASE │ run
      START │ ./plan.py
-   SUCCESS │ ./plan.py
-      FAIL │ cat static/foo/bar/README.md
+      FAIL │ ./plan.py
 ────────────────────────────────── Step info ───────────────────────────────────
-Command               cat static/foo/bar/README.md
-──────────────────────────────── Invalid inputs ────────────────────────────────
-STATIC Path does not exist: static/foo/bar/README.md
+Command               ./plan.py
+Return code           1
+──────────────────────────────── Standard error ────────────────────────────────
+(stripped)
 ────────────────────────────────────────────────────────────────────────────────
    WARNING │ 1 step(s) failed, see error messages above
    WARNING │ Skipping cleanup due to incomplete build.
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
+     PHASE │ watch
   DIRECTOR │ Stopping workers.
-     ERROR │ The director raised an exception.
-────────────────────────────────── Traceback ───────────────────────────────────
-Traceback (most recent call last):
-  File "${PWD}/stepup/core/director.py", line ---, in async_main
-    await serve(
-  File "${PWD}/stepup/core/director.py", line ---, in serve
-    await asyncio.gather(watcher_loop, runner_loop, rpc_director)
-  File "${PWD}/stepup/core/watcher.py", line ---, in loop
-    await dir_loop
-  File "${PWD}/stepup/core/watcher.py", line ---, in dir_loop
-    raise FileNotFoundError(f"Cannot watch non-existing directory: {path}")
-FileNotFoundError: Cannot watch non-existing directory: static/
-────────────────────────────────────────────────────────────────────────────────
   DIRECTOR │ See you!

--- a/tests/cases/error_overlap_deferred/README.md
+++ b/tests/cases/error_overlap_deferred/README.md
@@ -1,2 +1,1 @@
-A simple example of a cyclic dependency: `plan.py` declares the static file `README.md`,
-and then wants to use it as an input through the `amend` function.
+A simple example with a single file matching two deferred globs, which is not allowed.

--- a/tests/cases/error_overlap_deferred/expected_graph.txt
+++ b/tests/cases/error_overlap_deferred/expected_graph.txt
@@ -1,26 +1,35 @@
 root:
              version = v1
+             creates   file:./
+             creates   file:plan.py
+             creates   step:./plan.py
 
-(file:plan.py)
+file:plan.py
                 path = plan.py
                state = STATIC
-            consumes   (file:./)
+          created by   root:
+            consumes   file:./
+            supplies   step:./plan.py
 
-(file:./)
+file:./
                 path = ./
                state = STATIC
-            supplies   (file:plan.py)
+          created by   root:
+            supplies   file:plan.py
+            supplies   step:./plan.py
 
-(step:./plan.py)
+step:./plan.py
              workdir = ./
              command = ./plan.py
-               state = PENDING
+               state = FAILED
+          created by   root:
+            consumes   file:./
+            consumes   file:plan.py
+             creates   dg:'*.md'
+             creates   dg:'README.*'
 
-(dg:'README.*')
+dg:'README.*'
+          created by   step:./plan.py
 
-(dg:'*.md')
-
-(step:cat README.md)
-             workdir = ./
-             command = cat README.md
-               state = PENDING
+dg:'*.md'
+          created by   step:./plan.py

--- a/tests/cases/error_overlap_deferred/expected_stdout.txt
+++ b/tests/cases/error_overlap_deferred/expected_stdout.txt
@@ -9,10 +9,8 @@ Return code           1
 (stripped)
 ────────────────────────────────────────────────────────────────────────────────
    WARNING │ 1 step(s) failed, see error messages above
-   WARNING │ Scheduler is put on hold. Not reporting pending steps.
    WARNING │ Skipping cleanup due to incomplete build.
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-   WARNING │ Dissolving the workflow due to an exceptions while the graph was being changed.
      PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/tests/cases/restart_deferred_glob/expected_graph_01.txt
+++ b/tests/cases/restart_deferred_glob/expected_graph_01.txt
@@ -37,6 +37,20 @@ dg:'static/**'
              creates   file:static/
              creates   file:static/foo.txt
 
+file:static/
+                path = static/
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:./
+            supplies   file:static/foo.txt
+
+file:static/foo.txt
+                path = static/foo.txt
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:static/
+            supplies   step:cp -aT static/foo.txt bar.txt
+
 step:cp -aT static/foo.txt bar.txt
              workdir = ./
              command = cp -aT static/foo.txt bar.txt
@@ -47,20 +61,6 @@ step:cp -aT static/foo.txt bar.txt
             consumes   file:static/foo.txt
              creates   file:bar.txt
             supplies   file:bar.txt
-
-file:static/foo.txt
-                path = static/foo.txt
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:static/
-            supplies   step:cp -aT static/foo.txt bar.txt
-
-file:static/
-                path = static/
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:./
-            supplies   file:static/foo.txt
 
 file:bar.txt
                 path = bar.txt

--- a/tests/cases/restart_deferred_glob/expected_graph_02.txt
+++ b/tests/cases/restart_deferred_glob/expected_graph_02.txt
@@ -37,6 +37,20 @@ dg:'static/**'
              creates   file:static/
              creates   file:static/foo.txt
 
+file:static/
+                path = static/
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:./
+            supplies   file:static/foo.txt
+
+file:static/foo.txt
+                path = static/foo.txt
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:static/
+            supplies   step:cp -aT static/foo.txt bar.txt
+
 step:cp -aT static/foo.txt bar.txt
              workdir = ./
              command = cp -aT static/foo.txt bar.txt
@@ -47,20 +61,6 @@ step:cp -aT static/foo.txt bar.txt
             consumes   file:static/foo.txt
              creates   file:bar.txt
             supplies   file:bar.txt
-
-file:static/foo.txt
-                path = static/foo.txt
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:static/
-            supplies   step:cp -aT static/foo.txt bar.txt
-
-file:static/
-                path = static/
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:./
-            supplies   file:static/foo.txt
 
 file:bar.txt
                 path = bar.txt

--- a/tests/cases/restart_deferred_glob/expected_graph_03.txt
+++ b/tests/cases/restart_deferred_glob/expected_graph_03.txt
@@ -37,6 +37,20 @@ dg:'static/**'
              creates   file:static/
              creates   file:static/foo.txt
 
+file:static/
+                path = static/
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:./
+            supplies   file:static/foo.txt
+
+file:static/foo.txt
+                path = static/foo.txt
+               state = STATIC
+          created by   dg:'static/**'
+            consumes   file:static/
+            supplies   step:cp -aT static/foo.txt bar.txt
+
 step:cp -aT static/foo.txt bar.txt
              workdir = ./
              command = cp -aT static/foo.txt bar.txt
@@ -47,20 +61,6 @@ step:cp -aT static/foo.txt bar.txt
             consumes   file:static/foo.txt
              creates   file:bar.txt
             supplies   file:bar.txt
-
-file:static/foo.txt
-                path = static/foo.txt
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:static/
-            supplies   step:cp -aT static/foo.txt bar.txt
-
-file:static/
-                path = static/
-               state = STATIC
-          created by   dg:'static/**'
-            consumes   file:./
-            supplies   file:static/foo.txt
 
 file:bar.txt
                 path = bar.txt


### PR DESCRIPTION
bugfix ...

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where non-existing static file nodes were created from deferred glob matches. It introduces enhancements to verify the existence of these matches before marking them as static, adds new methods for handling deferred globs, and updates relevant tests and documentation.

* **Bug Fixes**:
    - Prevented the creation of non-existing static file nodes from deferred glob matches.
* **Enhancements**:
    - Introduced a mechanism to verify the existence of deferred glob matches before marking them as static.
    - Added new methods to handle deferred glob matches, including `filter_deferred` and `confirm_deferred`.
    - Updated the `declare_static` method to support a `verified` parameter, allowing paths to be marked as MISSING if not verified.
    - Enhanced the `supply_file` method to simplify the handling of deferred glob matches.
* **Documentation**:
    - Updated the changelog to include the fix for the `Cannot watch non-existing directory` error.
    - Revised the README in the `tests/cases/error_overlap_deferred` directory to reflect the new behavior of deferred globs.
* **Tests**:
    - Added tests to validate the new behavior of deferred globs, including checking and confirming their existence.
    - Updated existing tests to align with the new deferred glob handling logic.

<!-- Generated by sourcery-ai[bot]: end summary -->