### PR TITLE
Do not watch files is noninteractive mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ async def client(tmpdir) -> Iterator[AsyncRPCClient]:
         os.chmod("plan.py", stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
         reporter = ReporterClient()
         director = asyncio.create_task(
-            serve(director_socket_path, 1, "graph.mpk", "plan.py", reporter, False, False)
+            serve(director_socket_path, 1, "graph.mpk", "plan.py", reporter, False, False, True)
         )
         while not director_socket_path.exists():
             await asyncio.sleep(0.1)


### PR DESCRIPTION
When StepUp needs to watch changes in many directories, it hits a limitation of the watchdog library, causing the following exception:

```
OSError: [Errno 24] inotify instance limit reached
```

The relevant `watchdog` issues are:

- https://github.com/gorakhargosh/watchdog/issues/846
- https://github.com/gorakhargosh/watchdog/issues/275

As mentioned in the discussions, fixing this in watchdog requires some refactoring, so a quick fix is unlikely.

As a workafound, this PR ensures that the `-n` option of StepUp eliminates file watching altogether.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a '--non-interactive' option to the StepUp tool, which disables file watching when the tool is run in non-interactive mode. This change addresses issues related to hitting the inotify instance limit when watching many directories.

* **Enhancements**:
    - Added a '--non-interactive' option to disable file watching in non-interactive mode, preventing inotify instance limit errors.

<!-- Generated by sourcery-ai[bot]: end summary -->