### PR TITLE
Fix Python 3.11 specific RPC issue

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add workaround for Python==3.11 bug with RPC over sockets.
+  The RPC server (created with `asyncio.start_unix_server`) closes before all requests are handled.
+  A stop event is now included for all RPC handlers
+  to wait with stopping the server until every request is handled.
+
+
 ## [1.2.6] - 2024-06-13 {: #v1.2.6 }
 
 ### Fixed

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -95,7 +95,6 @@ async def test_stdio_simple_args(ic):
 REASON_SOCKET = "sockets hang in 3.11"
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 async def test_socket_simple_args(sc):
     assert await sc.call.echo("hello") == "socket: hello"
@@ -111,7 +110,6 @@ async def test_stdio_simple_kwargs(ic):
     assert await ic.call.echo(msg="hello") == "stdio: hello"
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 async def test_socket_simple_kwargs(sc):
     assert await sc.call.echo(msg="hello") == "socket: hello"
@@ -140,7 +138,6 @@ async def test_stdio_lcg_kwargs(ic, args, kwargs, result):
     assert await ic.call.lcg(*args, **kwargs) == result
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 @pytest.mark.parametrize(("args", "kwargs", "result"), LCG_CASES)
 async def test_socket_lcg_kwargs(sc, args, kwargs, result):
@@ -159,7 +156,6 @@ async def test_stdio_seq(ic):
     assert await ic.call.echo("world") == "stdio: world"
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 async def test_socket_seq(sc):
     assert await sc.call.echo("hello", 0.1) == "socket: hello"
@@ -178,7 +174,6 @@ async def test_stdio_par1(ic):
     assert await asyncio.gather(ic.call.echo("hello", 0.1), ic.call.echo("world")) == expected
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 async def test_socket_par1(sc):
     expected = ["socket: hello", "socket: world"]
@@ -197,14 +192,12 @@ async def test_stdio_par2(ic):
     assert await asyncio.gather(ic.call.echo("hello"), ic.call.echo("world", 0.1)) == expected
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 async def test_socket_par2(sc):
     expected = ["socket: hello", "socket: world"]
     assert await asyncio.gather(sc.call.echo("hello"), sc.call.echo("world", 0.1)) == expected
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 @pytest.mark.asyncio()
 async def test_socket_multi_clients(socket_server_path):
     r1, w1 = await asyncio.open_unix_connection(socket_server_path)
@@ -220,7 +213,6 @@ async def test_socket_multi_clients(socket_server_path):
             assert await asyncio.gather(c2.call.echo("h"), c1.call.echo("w", 0.1)) == expected
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 11), reason=REASON_SOCKET)
 def test_sync_socket_rpc_client(socket_server_path):
     with SocketSyncRPCClient(socket_server_path) as client:
         assert client.call.echo("hello", _rpc_timeout=5) == "socket: hello"


### PR DESCRIPTION
bugfix ...

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a specific issue with RPC over sockets in Python 3.11 by adding stop events to ensure the server waits for all requests to be handled before closing. The changelog has been updated to reflect this fix, and tests that were previously skipped for Python 3.11 have been re-enabled.

- **Bug Fixes**:
    - Implemented a workaround for a Python 3.11 specific issue where the RPC server closes before all requests are handled by adding stop events for each handler.
- **Documentation**:
    - Updated the changelog to document the workaround for the Python 3.11 RPC issue.
- **Tests**:
    - Removed the skip conditions for tests that were previously skipped for Python 3.11 due to the RPC issue, ensuring they now run and validate the new workaround.

<!-- Generated by sourcery-ai[bot]: end summary -->