### PR TITLE
Add support for standard output and error redirection to script driver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,12 @@ repos:
   hooks:
     - id: remove-crlf
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.5
+  rev: v0.5.1
   hooks:
     - id: ruff-format
     - id: ruff
       args: ["--fix", "--show-fixes"]
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.4
+  rev: 0.29.0
   hooks:
     - id: check-github-workflows

--- a/docs/advanced_topics/amending_static_inputs/stdout.txt
+++ b/docs/advanced_topics/amending_static_inputs/stdout.txt
@@ -7,6 +7,5 @@
 This is a config file.
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/amending_steps/stdout.txt
+++ b/docs/advanced_topics/amending_steps/stdout.txt
@@ -19,6 +19,5 @@ Contents of input.txt:
 You better read this.
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/blocked_steps/stdout.txt
+++ b/docs/advanced_topics/blocked_steps/stdout.txt
@@ -11,6 +11,5 @@ step:cp -aT a.txt b.txt
 ────────────────────────────────────────────────────────────────────────────────
    WARNING │ Skipping cleanup due to incomplete build.
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/cyclic_dependencies/stdout.txt
+++ b/docs/advanced_topics/cyclic_dependencies/stdout.txt
@@ -15,19 +15,19 @@ Traceback (most recent call last):
   File "/home/toon/univ/reprep/stepup-core/stepup/core/api.py", line 303, in step
     return RPC_CLIENT.call.step(
            ^^^^^^^^^^^^^^^^^^^^^
-  File "/home/toon/univ/reprep/stepup-core/stepup/core/rpc.py", line 436, in __call__
+  File "/home/toon/univ/reprep/stepup-core/stepup/core/rpc.py", line 448, in __call__
     _handle_error(body, name, args, kwargs)
-  File "/home/toon/univ/reprep/stepup-core/stepup/core/rpc.py", line 68, in _handle_error
+  File "/home/toon/univ/reprep/stepup-core/stepup/core/rpc.py", line 69, in _handle_error
     raise RPCError(f"An exception was raised in the server during the call {fmt_call}: \n\n{body}")
 stepup.core.exceptions.RPCError: An exception was raised in the server during the call step('step:./plan.py', 'cp -aT b.txt a.txt', [Path('b.txt')], [], [Path('a.txt')], [], Path('./'), False, None, False):
 Traceback (most recent call last):
-  File "/home/toon/univ/reprep/stepup-core/stepup/core/rpc.py", line 193, in _handle_request
+  File "/home/toon/univ/reprep/stepup-core/stepup/core/rpc.py", line 194, in _handle_request
     result = call(*bound.args, **bound.kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/toon/univ/reprep/stepup-core/stepup/core/director.py", line 359, in step
+  File "/home/toon/univ/reprep/stepup-core/stepup/core/director.py", line 376, in step
     return self._workflow.define_step(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  File "/home/toon/univ/reprep/stepup-core/stepup/core/workflow.py", line 623, in define_step
+  File "/home/toon/univ/reprep/stepup-core/stepup/core/workflow.py", line 622, in define_step
     self.create_file(step_key, out_path, FileState.PENDING)
   File "/home/toon/univ/reprep/stepup-core/stepup/core/workflow.py", line 375, in create_file
     self.supply(creator_key, file_key)
@@ -51,6 +51,5 @@ cycle:
    WARNING │ Skipping cleanup due to incomplete build.
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
    WARNING │ Dissolving the workflow due to an exceptions while the graph was being changed.
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/environment_variables/stdout.txt
+++ b/docs/advanced_topics/environment_variables/stdout.txt
@@ -9,6 +9,5 @@
 foo
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/here_and_root/stdout.txt
+++ b/docs/advanced_topics/here_and_root/stdout.txt
@@ -12,6 +12,5 @@
      START │ cp -aT example.txt ../../public/sub/example.txt  # wd=sub/
    SUCCESS │ cp -aT example.txt ../../public/sub/example.txt  # wd=sub/
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/optional_steps/stdout.txt
+++ b/docs/advanced_topics/optional_steps/stdout.txt
@@ -12,6 +12,5 @@
      START │ ./plot.py run
    SUCCESS │ ./plot.py run
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/pools/stdout.txt
+++ b/docs/advanced_topics/pools/stdout.txt
@@ -22,6 +22,5 @@ A
 C
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/static_deferred_glob/stdout.txt
+++ b/docs/advanced_topics/static_deferred_glob/stdout.txt
@@ -9,6 +9,5 @@
 This is foo.
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/static_named_glob/stdout.txt
+++ b/docs/advanced_topics/static_named_glob/stdout.txt
@@ -28,6 +28,5 @@
      START │ cat ch4/sec4_1_summary.md > public/ch4.md
    SUCCESS │ cat ch4/sec4_1_summary.md > public/ch4.md
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/variable_substitution/stdout.txt
+++ b/docs/advanced_topics/variable_substitution/stdout.txt
@@ -6,6 +6,5 @@
      START │ ./step.py < src_foo.txt > dst_foo.txt
    SUCCESS │ ./step.py < src_foo.txt > dst_foo.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/advanced_topics/volatile_outputs/stdout.txt
+++ b/docs/advanced_topics/volatile_outputs/stdout.txt
@@ -6,6 +6,5 @@
      START │ date > date.txt
    SUCCESS │ date > date.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for standard output and error redirection in the script driver.
+  The dictionary returned by the `info` or `case_info` functions
+  can include `"stdout"` and/or `"stderr"` items.
+  The values of these two fields are paths to which the standard output and/or error
+  of the run part of the script are redirected.
+
+
 ## [1.2.8] - 2024-06-28 {: #v1.2.8 }
 
 ### Fixed

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,7 +26,7 @@ The documentation is created using [MkDocs](https://www.mkdocs.org/).
 Edit the documentation Markdown files with a live preview by running:
 
 ```bash
-mkdocs serve --watch stepup/core/
+mkdocs serve
 ```
 
 (Keep this running.)

--- a/docs/getting_started/copy_mkdir/stdout.txt
+++ b/docs/getting_started/copy_mkdir/stdout.txt
@@ -8,9 +8,8 @@
      START │ mkdir -p sub/
    SUCCESS │ mkdir -p sub/
      START │ cp -aT hello.txt sub/hello.txt
-   SUCCESS │ ./plan.py
    SUCCESS │ cp -aT hello.txt sub/hello.txt
+   SUCCESS │ ./plan.py
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/dependencies/stdout.txt
+++ b/docs/getting_started/dependencies/stdout.txt
@@ -3,15 +3,14 @@
   DIRECTOR │ Launched worker 1
      PHASE │ run
      START │ ./plan.py
+   SUCCESS │ ./plan.py
      START │ echo First line. > story.txt; echo Second line. >> story.txt
    SUCCESS │ echo First line. > story.txt; echo Second line. >> story.txt
      START │ grep First story.txt
-   SUCCESS │ ./plan.py
    SUCCESS │ grep First story.txt
 ─────────────────────────────── Standard output ────────────────────────────────
 First line.
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/distributed_plans/stdout.txt
+++ b/docs/getting_started/distributed_plans/stdout.txt
@@ -16,6 +16,5 @@ This is part 2.
 This is part 1.
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/first_step.md
+++ b/docs/getting_started/first_step.md
@@ -81,8 +81,12 @@ StepUp will not know anymore that it already executed some steps and runs all of
   process when `plan.py` is executed by `stepup`.
   You should get the following screen output.
 
+{% macro incl() %}
+{% include "getting_started/first_step/stdout3.txt" %}
+{% endmacro %}
+
     ```
-    {% include 'getting_started/first_step/stdout3.txt' | indent(width=4) %}
+    {{ incl() | indent(width=4) }}
     ```
 
     This output contains internal details of StepUp,

--- a/docs/getting_started/first_step/stdout1.txt
+++ b/docs/getting_started/first_step/stdout1.txt
@@ -5,10 +5,9 @@
    SUCCESS │ ./plan.py
      START │ echo Hello World
    SUCCESS │ echo Hello World
-───────────────────────────────────────── Standard output ──────────────────────────────────────────
+─────────────────────────────── Standard output ────────────────────────────────
 Hello World
-────────────────────────────────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/first_step/stdout2.txt
+++ b/docs/getting_started/first_step/stdout2.txt
@@ -5,6 +5,5 @@
       SKIP │ ./plan.py
       SKIP │ echo Hello World
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/first_step/stdout3.txt
+++ b/docs/getting_started/first_step/stdout3.txt
@@ -1,2 +1,0 @@
-filter_deferred([])
-step('dummy:', 'echo Hello World', [], [], [], [], Path('./'), False, None, False)

--- a/docs/getting_started/no_rules/stdout.txt
+++ b/docs/getting_started/no_rules/stdout.txt
@@ -8,6 +8,5 @@
      START │ tr '[:lower:]' '[:upper:]' < lower2.txt > upper2.txt
    SUCCESS │ tr '[:lower:]' '[:upper:]' < lower2.txt > upper2.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/script_multiple.md
+++ b/docs/getting_started/script_multiple.md
@@ -23,6 +23,9 @@ def case_info(case: int):
     return {
         "inp": ..., # a single input path or a list of input paths
         "out": ..., # a single output path or a list of input paths
+        "static": ..., # declare a static file or a list of static files
+        "stdout": ..., # redirect the standard output to a file (StepUp 1.3.0)
+        "stderr": ..., # redirect the standard error to a file (StepUp 1.3.0)
         "just_any": "argument that you want to add",
     }
 
@@ -56,6 +59,8 @@ The script has the following elements:
 
 - The function `case_info()` is used to translate `args` and `kwargs` into a more detailed
   planning of the run steps.
+  The returned dictionary is handled in the same way as that of the `info()` function in
+  the previous tutorial [Script (Single Case)](script_single.md#single-case-script-driver)
 
 - The function `run()` works in the same way as for the single case script driver.
 
@@ -117,4 +122,22 @@ This produces the following figures:
     def cases():
         from settings import airports
         yield from airports
+    ```
+
+- For debugging purposes, it is somtimes useful to just run a single case of a script.
+  To facilitate this type of debugging, the script can be called with the `cases` argument.
+  When you run the following command:
+
+    ```bash
+    ./plot.py cases
+    ```
+
+    you get a list with different ways of running the `run()` function of the script:
+
+{% macro incl() %}
+{% include "getting_started/script_multiple/cases_out.txt" %}
+{% endmacro %}
+
+    ```bash
+    {{ incl() | indent(width=4) }}
     ```

--- a/docs/getting_started/script_multiple.md
+++ b/docs/getting_started/script_multiple.md
@@ -60,7 +60,7 @@ The script has the following elements:
 - The function `case_info()` is used to translate `args` and `kwargs` into a more detailed
   planning of the run steps.
   The returned dictionary is handled in the same way as that of the `info()` function in
-  the previous tutorial [Script (Single Case)](script_single.md#single-case-script-driver)
+  the previous tutorial [Script (Single Case)](script_single.md#single-case-script-driver).
 
 - The function `run()` works in the same way as for the single case script driver.
 
@@ -124,7 +124,7 @@ This produces the following figures:
         yield from airports
     ```
 
-- For debugging purposes, it is somtimes useful to just run a single case of a script.
+- For debugging purposes, it is sometimes useful to run just a single case of a script.
   To facilitate this type of debugging, the script can be called with the `cases` argument.
   When you run the following command:
 
@@ -132,7 +132,7 @@ This produces the following figures:
     ./plot.py cases
     ```
 
-    you get a list with different ways of running the `run()` function of the script:
+    you will get a list of different ways to execute the script's `run()` function:
 
 {% macro incl() %}
 {% include "getting_started/script_multiple/cases_out.txt" %}

--- a/docs/getting_started/script_multiple/cases_out.txt
+++ b/docs/getting_started/script_multiple/cases_out.txt
@@ -1,0 +1,2 @@
+./plot.py run -- 'plot_ebbr'
+./plot.py run -- 'plot_ebos'

--- a/docs/getting_started/script_multiple/main.sh
+++ b/docs/getting_started/script_multiple/main.sh
@@ -2,6 +2,7 @@
 git clean -qdfX .
 unset STEPUP_ROOT
 stepup -n -w 1 | sed -f ../../clean_stdout.sed > stdout.txt
+./plot.py cases > cases_out.txt
 
 # INP: plan.py
 # INP: plot.py

--- a/docs/getting_started/script_multiple/stdout.txt
+++ b/docs/getting_started/script_multiple/stdout.txt
@@ -10,6 +10,5 @@
      START │ ./plot.py run -- 'plot_ebos'
    SUCCESS │ ./plot.py run -- 'plot_ebos'
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/script_single.md
+++ b/docs/getting_started/script_single.md
@@ -19,9 +19,9 @@ is roughly equivalent to:
 step("./executable plan", inp="sub/executable", workdir="sub/")
 ```
 
-Note that the use of subdirectory is not required.
-The step `./executable plan` is expected to define additional steps to actually run something useful with the executable.
-A common scenario is that it plans a single step `./executable run` with appropriate inputs and outputs.
+Note that the use of a subdirectory is not required.
+The `./executable plan` step is expected to define additional steps to actually run something useful with the executable.
+A common scenario is to plan a single `./executable run` step with appropriate inputs and outputs.
 
 When the `optional=True` keyword argument is given to the `script()` function,
 it executes `./executable plan --optional`.
@@ -68,25 +68,24 @@ if __name__ == "__main__":
     driver()
 ```
 
-- The `info` function provides the necessary data to implement
-  the planning of the execution of the script.
+- The `info` function provides the data necessary to plan the execution of the script.
   It is executed when calling the script as `./script.py plan`.
 
     !!! note
 
         All dictionary items are optional.
-        The `info` function may even return an empty dictionary.
+        The `info` function can even return an empty dictionary.
         The keys `inp`, `out`, `static`, `stdout` and `stderr` affect the planning the run part,
         as explained in the comments above.
 
 - The `run` function is called to perform the useful work and
-  is executed when running the script with `./script.py run`.
+  is executed when the script is executed as `./script.py run`.
 
     !!! note
 
-        The `run` function can have any argument defined in the dictionary return by `info`,
+        The `run` function can have any argument defined in the dictionary returned by `info`,
         but it does not have to specify all of them.
-        The argument list of `run` may also contain fewer arguments (or even none at all).
+        The argument list of `run` can contain fewer arguments (or even none at all).
 
 
 ## Example

--- a/docs/getting_started/script_single.md
+++ b/docs/getting_started/script_single.md
@@ -19,7 +19,7 @@ is roughly equivalent to:
 step("./executable plan", inp="sub/executable", workdir="sub/")
 ```
 
-where the subdirectory is optional.
+Note that the use of subdirectory is not required.
 The step `./executable plan` is expected to define additional steps to actually run something useful with the executable.
 A common scenario is that it plans a single step `./executable run` with appropriate inputs and outputs.
 
@@ -55,6 +55,9 @@ def info():
     return {
         "inp": ..., # a single input path or a list of input paths
         "out": ..., # a single output path or a list of input paths
+        "static": ..., # declare a static file or a list of static files
+        "stdout": ..., # redirect the standard output to a file (StepUp 1.3.0)
+        "stderr": ..., # redirect the standard error to a file (StepUp 1.3.0)
         "just_any": "argument that you want to add",
     }
 
@@ -69,12 +72,21 @@ if __name__ == "__main__":
   the planning of the execution of the script.
   It is executed when calling the script as `./script.py plan`.
 
+    !!! note
+
+        All dictionary items are optional.
+        The `info` function may even return an empty dictionary.
+        The keys `inp`, `out`, `static`, `stdout` and `stderr` affect the planning the run part,
+        as explained in the comments above.
+
 - The `run` function is called to perform the useful work and
   is executed when running the script with `./script.py run`.
 
-Note that the `run` function can have any argument defined in the dictionary return by `info`,
-but it does not have to specify all of them.
-The argument list of `run` may also contain fewer arguments (or even none at all).
+    !!! note
+
+        The `run` function can have any argument defined in the dictionary return by `info`,
+        but it does not have to specify all of them.
+        The argument list of `run` may also contain fewer arguments (or even none at all).
 
 
 ## Example

--- a/docs/getting_started/script_single/stdout.txt
+++ b/docs/getting_started/script_single/stdout.txt
@@ -8,6 +8,5 @@
      START │ ./generate.py run
    SUCCESS │ ./generate.py run
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/static_files/stdout.txt
+++ b/docs/getting_started/static_files/stdout.txt
@@ -6,6 +6,5 @@
      START │ nl limerick.txt > numbered.txt
    SUCCESS │ nl limerick.txt > numbered.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/static_glob/stdout.txt
+++ b/docs/getting_started/static_glob/stdout.txt
@@ -10,6 +10,5 @@
      START │ cp -aT src/foo.txt dst/foo.txt
    SUCCESS │ cp -aT src/foo.txt dst/foo.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/static_glob_conditional/stdout1.txt
+++ b/docs/getting_started/static_glob_conditional/stdout1.txt
@@ -11,6 +11,5 @@
 2.580000
 ────────────────────────────────────────────────────────────────────────────────
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/docs/getting_started/static_glob_conditional/stdout2.txt
+++ b/docs/getting_started/static_glob_conditional/stdout2.txt
@@ -6,6 +6,5 @@
    SUCCESS │ ./plan.py
       SKIP │ cat average.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
-     PHASE │ watch
   DIRECTOR │ Stopping workers.
   DIRECTOR │ See you!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,9 @@ plugins:
 - search:
     lang:
       - en
-- macros
+- macros:
+    on_error_fail: true
+    on_undefined: strict
 - mkdocstrings:
     default_handler: python
     handlers:

--- a/stepup/core/script.py
+++ b/stepup/core/script.py
@@ -33,131 +33,27 @@ from path import Path
 __all__ = ("driver",)
 
 
-def driver(obj=None) -> int:
-    """Driver function to be called from a script as `driver()` or `driver(obj)`.
-
-    Parameters
-    ----------
-    obj
-        When not provided, the namespace of the module where `driver` is defined
-        will be searched for names like 'info' and 'run' to implement the script protocol.
-        When an object is given as a parameter, its attributes are searched instead.
-    """
-    frame = inspect.currentframe().f_back
-    script_path = Path(frame.f_locals["__file__"]).relpath()
-    if obj is None:
-        # Get the calling module and use it as obj
-        module_name = frame.f_locals["__name__"]
-        obj = sys.modules.get(module_name)
-        if obj is None:
-            raise ValueError(
-                f"The driver must be called from an imported module, got {module_name}"
-            )
-    args = parse_args(script_path)
-    wrapper = ScriptWrapper(obj, script_path)
-
-    if args.cmd == "plan":
-        # Local import because the StepUp client is not always needed.
-        from stepup.core.api import amend, static, step
-
-        # Get paths for top-level local imports of the script.
-        # These are treated as dependencies for the run function of the script.
-        top_mod_paths = get_local_import_paths(script_path)
-
-        # Plan the script.
-        if wrapper.has_single:
-            if not amend(inp=top_mod_paths):
-                return 0
-            static_paths, inp_paths, out_paths = wrapper.get_plan()
-            inp_paths.extend(top_mod_paths)
-            inp_paths.append(script_path)
-            static(*static_paths)
-            step(f"./{script_path} run", inp=inp_paths, out=out_paths, optional=args.optional)
-        if wrapper.has_cases:
-            # First collect all cases
-            cases = list(wrapper.generate_cases())
-            # Include local imports, used to generate the cases, as inputs for the plan step.
-            plan_mod_paths = get_local_import_paths(script_path)
-            if not amend(inp=plan_mod_paths):
-                return 0
-            # Then create steps for all cases
-            for case_args, case_kwargs in cases:
-                argstr = wrapper.format(*case_args, **case_kwargs)
-                static_paths, inp_paths, out_paths = wrapper.get_case_plan(
-                    *case_args, **case_kwargs
-                )
-                inp_paths.extend(top_mod_paths)
-                inp_paths.append(script_path)
-                static(*static_paths)
-                step(
-                    f"./{script_path} run -- '{argstr}'",
-                    inp=inp_paths,
-                    out=out_paths,
-                    optional=args.optional,
-                )
-        return 0
-    if args.cmd == "cases":
-        if wrapper.has_single:
-            print(f"./{script_path} run")
-        if wrapper.has_cases:
-            for case_args, case_kwargs in wrapper.generate_cases():
-                argstr = wrapper.format(*case_args, **case_kwargs)
-                print(f"./{script_path} run -- '{argstr}'")
-        return 0
-    if args.cmd == "run":
-        if args.string == "":
-            if not wrapper.has_single:
-                raise RuntimeError(f"Script has no info function: {script_path}")
-            info = wrapper.filter_info(wrapper.get_info())
-            return wrapper.run(**info)
-        if not wrapper.has_cases:
-            raise RuntimeError(f"Script has no case_info function: {script_path}")
-        case_args, case_kwargs = wrapper.parse(args.string)
-        info = wrapper.filter_info(wrapper.get_case_info(*case_args, **case_kwargs))
-        return wrapper.run(**info)
-    raise NotImplementedError
-
-
-def parse_args(script_path: str) -> argparse.Namespace:
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(
-        prog=script_path, description=f"StepUp driver for script {script_path}."
-    )
-    sub_parsers = parser.add_subparsers(dest="cmd")
-    sub_parsers.required = True
-
-    # plan
-    plan_parser = sub_parsers.add_parser(
-        "plan",
-        description="Submit a plan for executing the script to the director.",
-    )
-    plan_parser.add_argument(
-        "-o", "--optional", default=False, action="store_true", help="Make the run steps optional."
-    )
-
-    # cases
-    sub_parsers.add_parser("cases", description="Print all ways to run the script.")
-
-    # run
-    run_parser = sub_parsers.add_parser("run", description="Print all ways to run the script.")
-    run_parser.add_argument(
-        "string",
-        default="",
-        nargs="?",
-        help="A string describing the parameters with which to run the script",
-    )
-
-    return parser.parse_args()
-
-
 @attrs.define
 class ScriptWrapper:
     """A wrapper for the script being planned and executed."""
 
     _object: Any = attrs.field()
+    """
+    The object containing the functions to plan and run the script.
+    This can be a module whose functions are used or an object whose methods are used.
+    """
+
     _script_path: Path = attrs.field()
+    """The path of the script relative to the work directory."""
+
     _has_single: bool = attrs.field(init=False)
+    """Whether the script has functions for a single execution: `info` and `run`."""
+
     _has_cases: bool = attrs.field(init=False)
+    """
+    Whether the script has functions for multiple executions:
+    `CASE_FMT`, `cases`, `case_info` and `run`.
+    """
 
     @_has_single.default
     def _default_has_singe(self) -> bool:
@@ -208,22 +104,52 @@ class ScriptWrapper:
     # Wrapper methods
 
     def get_info(self) -> dict:
+        """Get the return value of the `info` function."""
         if not self._has_single:
             raise NotImplementedError("get_info only works for scripts with an info function")
         info = self._object.info()
         if not isinstance(info, dict):
             raise TypeError("info must return a dictionary.")
+        if not all(isinstance(key, str) for key in info):
+            raise TypeError("All keys of the info dict must be strings.")
         return info
 
-    def get_plan(self) -> tuple[list[str], list[str], list[str]]:
+    def get_plan(self) -> tuple[list[str], list[str], list[str], str | None, str | None]:
+        """Return a tuple with normalized information from the info dictionary (single run).
+
+        Returns
+        -------
+        static_paths
+            A list of files that (only) this script declares to be static.
+            When static files are used by multiple steps, take care to declare it static only once.
+        inp_paths
+            A list of input paths.
+        out_paths
+            A list of output paths.
+        stdout_path
+            A path to redirect the standard output to.
+        stderr_path
+            A path to redirect the standard error to.
+        """
         info = self.get_info()
         return (
             _get_path_list("static", info, self._script_path, "info"),
             _get_path_list("inp", info, self._script_path, "info"),
             _get_path_list("out", info, self._script_path, "info"),
+            _get_optional_path("stdout", info, self._script_path, "info"),
+            _get_optional_path("stderr", info, self._script_path, "info"),
         )
 
     def generate_cases(self) -> Iterator[tuple[list, dict]]:
+        """Run the `cases` generator and normalize the iterates.
+
+        Yields
+        ------
+        args
+            Unnamed arguments for the `info` function.
+        kwargs
+            Named arguments for the `info` function.
+        """
         if not self._has_cases:
             raise NotImplementedError("generate_cases only works for scripts with multiple cases")
         for case in self._object.cases():
@@ -242,6 +168,7 @@ class ScriptWrapper:
                 yield [case], {}
 
     def format(self, *args, **kwargs) -> str:
+        """Convert a (normalized) iterate from the `cases` function into a string."""
         if not self._has_cases:
             raise NotImplementedError("format only works for scripts with multiple cases")
         if not isinstance(self._object.CASE_FMT, str):
@@ -249,6 +176,7 @@ class ScriptWrapper:
         return self._object.CASE_FMT.format(*args, **kwargs)
 
     def parse(self, argstr: str) -> tuple[tuple, dict]:
+        """Convert a string back into `args` and `kwargs`. (Inverse of `format`.)"""
         if not self._has_cases:
             raise NotImplementedError("parse only works for scripts with multiple cases")
         case_fmt = self._object.CASE_FMT
@@ -258,27 +186,185 @@ class ScriptWrapper:
         return result.fixed, result.named
 
     def get_case_info(self, *args, **kwargs) -> dict:
+        """Get the return value of the `info` function."""
         if not self._has_cases:
             raise NotImplementedError("get_case_info only works for scripts with multiple cases")
         info = self._object.case_info(*args, **kwargs)
         if not isinstance(info, dict):
             raise TypeError("case_info must return a dictionary.")
+        if not all(isinstance(key, str) for key in info):
+            raise TypeError("All keys of the info dict must be strings.")
         return info
 
-    def get_case_plan(self, *args, **kwargs) -> tuple[list[str], list[str], list[str]]:
+    def get_case_plan(
+        self, *args, **kwargs
+    ) -> tuple[list[str], list[str], list[str], str | None, str | None]:
+        """Return a tuple with normalized information from the info dictionary (multiple runs).
+
+        Returns
+        -------
+        static_paths
+            A list of files that (only) this script declares to be static.
+            When static files are used by multiple steps, take care to declare it static only once.
+        inp_paths
+            A list of input paths.
+        out_paths
+            A list of output paths.
+        stdout_path
+            A path to redirect the standard output to.
+        stderr_path
+            A path to redirect the standard error to.
+        """
         info = self.get_case_info(*args, **kwargs)
         return (
             _get_path_list("static", info, self._script_path, "case_info"),
             _get_path_list("inp", info, self._script_path, "case_info"),
             _get_path_list("out", info, self._script_path, "case_info"),
+            _get_optional_path("stdout", info, self._script_path, "case_info"),
+            _get_optional_path("stderr", info, self._script_path, "case_info"),
         )
 
     def filter_info(self, info: dict) -> dict:
+        """Return a reduce info dictionary with only the arguments used by the `run` function."""
         run_signature = inspect.signature(self._object.run)
         return {key: value for key, value in info.items() if key in run_signature.parameters}
 
-    def run(self, **kwargs) -> int:
-        return self._object.run(**kwargs)
+    def run(self, **filtered_info):
+        """Call the `run` function."""
+        self._object.run(**filtered_info)
+
+
+def driver(obj=None):
+    """Driver function to be called from a script as `driver()` or `driver(obj)`.
+
+    Parameters
+    ----------
+    obj
+        When not provided, the namespace of the module where `driver` is defined
+        will be searched for names like 'info' and 'run' to implement the script protocol.
+        When an object is given as a parameter, its attributes are searched instead.
+    """
+    frame = inspect.currentframe().f_back
+    script_path = Path(frame.f_locals["__file__"]).relpath()
+    if obj is None:
+        # Get the calling module and use it as obj
+        module_name = frame.f_locals["__name__"]
+        obj = sys.modules.get(module_name)
+        if obj is None:
+            raise ValueError(
+                f"The driver must be called from an imported module, got {module_name}"
+            )
+    args = parse_args(script_path)
+    wrapper = ScriptWrapper(obj, script_path)
+    if args.cmd == "plan":
+        _driver_plan(script_path, args, wrapper)
+    elif args.cmd == "cases":
+        _driver_cases(script_path, wrapper)
+    elif args.cmd == "run":
+        _driver_run(script_path, args, wrapper)
+    else:
+        raise NotImplementedError
+
+
+def parse_args(script_path: str) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        prog=script_path, description=f"StepUp driver for script {script_path}."
+    )
+    sub_parsers = parser.add_subparsers(dest="cmd")
+    sub_parsers.required = True
+
+    # plan
+    plan_parser = sub_parsers.add_parser(
+        "plan",
+        description="Submit a plan for executing the script to the director.",
+    )
+    plan_parser.add_argument(
+        "-o", "--optional", default=False, action="store_true", help="Make the run steps optional."
+    )
+
+    # cases
+    sub_parsers.add_parser("cases", description="Print all ways to run the script.")
+
+    # run
+    run_parser = sub_parsers.add_parser("run", description="Print all ways to run the script.")
+    run_parser.add_argument(
+        "string",
+        default="",
+        nargs="?",
+        help="A string describing the parameters with which to run the script",
+    )
+
+    return parser.parse_args()
+
+
+def _driver_plan(script_path: str, args: argparse.Namespace, wrapper: ScriptWrapper):
+    """Create the step to plan the run part of the script."""
+    # Local import because the StepUp client is not always needed.
+    from stepup.core.api import amend, static, step
+
+    # Get paths for top-level local imports of the script.
+    # These are treated as dependencies for the run function of the script.
+    top_mod_paths = _get_local_import_paths(script_path)
+
+    # Plan the script.
+    if wrapper.has_single:
+        if not amend(inp=top_mod_paths):
+            return None
+        static_paths, inp_paths, out_paths, stdout_path, stderr_path = wrapper.get_plan()
+        inp_paths.extend(top_mod_paths)
+        inp_paths.append(script_path)
+        static(*static_paths)
+        command = _add_redirects(f"./{script_path} run", out_paths, stdout_path, stderr_path)
+        step(command, inp=inp_paths, out=out_paths, optional=args.optional)
+    if wrapper.has_cases:
+        # First collect all cases
+        cases = list(wrapper.generate_cases())
+        # Include local imports, used to generate the cases, as inputs for the plan step.
+        plan_mod_paths = _get_local_import_paths(script_path)
+        if not amend(inp=plan_mod_paths):
+            return 0
+        # Then create steps for all cases
+        for case_args, case_kwargs in cases:
+            argstr = wrapper.format(*case_args, **case_kwargs)
+            static_paths, inp_paths, out_paths, stdout_path, stderr_path = wrapper.get_case_plan(
+                *case_args, **case_kwargs
+            )
+            inp_paths.extend(top_mod_paths)
+            inp_paths.append(script_path)
+            static(*static_paths)
+            command = f"./{script_path} run -- '{argstr}'"
+            command = _add_redirects(command, out_paths, stdout_path, stderr_path)
+            step(
+                command,
+                inp=inp_paths,
+                out=out_paths,
+                optional=args.optional,
+            )
+
+
+def _driver_cases(script_path: str, wrapper: ScriptWrapper):
+    """Print all commands on script that can be used to run the script."""
+    if wrapper.has_single:
+        print(f"./{script_path} run")
+    if wrapper.has_cases:
+        for case_args, case_kwargs in wrapper.generate_cases():
+            argstr = wrapper.format(*case_args, **case_kwargs)
+            print(f"./{script_path} run -- '{argstr}'")
+
+
+def _driver_run(script_path: str, args: argparse.Namespace, wrapper: ScriptWrapper):
+    """Call the `run` function with the appropriate arguments."""
+    if args.string == "":
+        if not wrapper.has_single:
+            raise RuntimeError(f"Script has no info function: {script_path}")
+        info = wrapper.filter_info(wrapper.get_info())
+        return wrapper.run(**info)
+    if not wrapper.has_cases:
+        raise RuntimeError(f"Script has no case_info function: {script_path}")
+    case_args, case_kwargs = wrapper.parse(args.string)
+    info = wrapper.filter_info(wrapper.get_case_info(*case_args, **case_kwargs))
+    wrapper.run(**info)
 
 
 def _get_path_list(name: str, info: dict, script_path: str, func_name: str) -> list[str]:
@@ -291,8 +377,17 @@ def _get_path_list(name: str, info: dict, script_path: str, func_name: str) -> l
     return paths
 
 
-def get_local_import_paths(script_path: Path) -> list[str]:
-    # Get paths for all local imports
+def _get_optional_path(name: str, info: dict, script_path: str, func_name: str) -> str | None:
+    """Get an optional path from the info dict."""
+    path = info.get(name)
+    if path is None or isinstance(path, str):
+        return path
+    raise TypeError(f"{name} is not a string (or None) in function {func_name} in {script_path}")
+
+
+def _get_local_import_paths(script_path: Path) -> list[str]:
+    """Get all local files from `sys.modules`, exclude files outside `STEPUP_ROOT`."""
+    # Get paths for all local imports.
     stepup_root = Path(os.environ.get("STEPUP_ROOT", Path.cwd())).normpath() / ""
     mod_paths = set()
     for module in sys.modules.values():
@@ -300,6 +395,43 @@ def get_local_import_paths(script_path: Path) -> list[str]:
         if mod_path is not None and mod_path.startswith(stepup_root):
             mod_paths.add(Path(mod_path).relpath())
 
-    # Amend the inputs of the planner with the local imports
+    # The script path is already included in the inputs.
     mod_paths.discard(script_path)
     return sorted(mod_paths)
+
+
+def _add_redirects(
+    command: str, out_paths: list[str], stdout_path: str | None, stderr_path: str | None
+) -> str:
+    """Add stdout and stderr to the command and update out_paths.
+
+    Parameters
+    ----------
+    command
+        The command without output and error redirection.
+    out_paths
+        The list of output paths before redirection.
+        This list will be updated with standard output and error paths if relevant.
+    stdout_path
+        The standard output path. Ignored if `None`. Not added to out_paths if `"/dev/null"`.
+    stderr_path
+        The standard error path. Ignored if `None`. Not added to out_paths if `"/dev/null"`.
+        Use `"__stdout__"` to redirect it to the same file as stdout (if any).
+
+    Returns
+    -------
+    command
+        The command with redirections included.
+    """
+    if stdout_path is not None:
+        if stderr_path == "__stdout__":
+            command += f" &> {stdout_path}"
+        else:
+            command += f" > {stdout_path}"
+        if stdout_path != "/dev/null":
+            out_paths.append(stdout_path)
+    if not (stderr_path is None or stderr_path == "__stdout__"):
+        command += f" 2> {stderr_path}"
+        if stderr_path != "/dev/null":
+            out_paths.append(stderr_path)
+    return command

--- a/stepup/core/script.py
+++ b/stepup/core/script.py
@@ -360,6 +360,7 @@ def _driver_run(script_path: str, args: argparse.Namespace, wrapper: ScriptWrapp
             raise RuntimeError(f"Script has no info function: {script_path}")
         info = wrapper.filter_info(wrapper.get_info())
         wrapper.run(**info)
+        return
     if not wrapper.has_cases:
         raise RuntimeError(f"Script has no case_info function: {script_path}")
     case_args, case_kwargs = wrapper.parse(args.string)

--- a/tests/cases/script_cases/.gitignore
+++ b/tests/cases/script_cases/.gitignore
@@ -2,3 +2,5 @@
 data-5.0.txt
 data+7.0.txt
 current_*
+stdout*.txt
+stderr*.txt

--- a/tests/cases/script_cases/expected_graph.txt
+++ b/tests/cases/script_cases/expected_graph.txt
@@ -19,11 +19,15 @@ file:./
             supplies   file:data-5.0.txt
             supplies   file:helper.py
             supplies   file:plan.py
+            supplies   file:stderr+7.0.txt
+            supplies   file:stderr-5.0.txt
+            supplies   file:stdout+7.0.txt
+            supplies   file:stdout-5.0.txt
             supplies   file:work.py
             supplies   step:./plan.py
             supplies   step:./work.py plan
-            supplies   step:./work.py run -- '+7.0'
-            supplies   step:./work.py run -- '-5.0'
+            supplies   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+            supplies   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
 
 step:./plan.py
              workdir = ./
@@ -42,8 +46,8 @@ file:helper.py
           created by   step:./plan.py
             consumes   file:./
             supplies   step:./work.py plan
-            supplies   step:./work.py run -- '+7.0'
-            supplies   step:./work.py run -- '-5.0'
+            supplies   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+            supplies   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
 
 file:work.py
                 path = work.py
@@ -51,8 +55,8 @@ file:work.py
           created by   step:./plan.py
             consumes   file:./
             supplies   step:./work.py plan
-            supplies   step:./work.py run -- '+7.0'
-            supplies   step:./work.py run -- '-5.0'
+            supplies   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+            supplies   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
 
 step:./work.py plan
              workdir = ./
@@ -63,41 +67,77 @@ step:./work.py plan
             consumes   file:./
             consumes   file:helper.py
             consumes   file:work.py
-             creates   step:./work.py run -- '+7.0'
-             creates   step:./work.py run -- '-5.0'
+             creates   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+             creates   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
 
-step:./work.py run -- '-5.0'
+step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
              workdir = ./
-             command = ./work.py run -- '-5.0'
+             command = ./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
                state = SUCCEEDED
           created by   step:./work.py plan
             consumes   file:./
             consumes   file:helper.py
             consumes   file:work.py
              creates   file:data-5.0.txt
+             creates   file:stderr-5.0.txt
+             creates   file:stdout-5.0.txt
             supplies   file:data-5.0.txt
+            supplies   file:stderr-5.0.txt
+            supplies   file:stdout-5.0.txt
 
 file:data-5.0.txt
                 path = data-5.0.txt
                state = BUILT
-          created by   step:./work.py run -- '-5.0'
+          created by   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
             consumes   file:./
-            consumes   step:./work.py run -- '-5.0'
+            consumes   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
 
-step:./work.py run -- '+7.0'
+file:stderr-5.0.txt
+                path = stderr-5.0.txt
+               state = BUILT
+          created by   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
+            consumes   file:./
+            consumes   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
+
+file:stdout-5.0.txt
+                path = stdout-5.0.txt
+               state = BUILT
+          created by   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
+            consumes   file:./
+            consumes   step:./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
+
+step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
              workdir = ./
-             command = ./work.py run -- '+7.0'
+             command = ./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
                state = SUCCEEDED
           created by   step:./work.py plan
             consumes   file:./
             consumes   file:helper.py
             consumes   file:work.py
              creates   file:data+7.0.txt
+             creates   file:stderr+7.0.txt
+             creates   file:stdout+7.0.txt
             supplies   file:data+7.0.txt
+            supplies   file:stderr+7.0.txt
+            supplies   file:stdout+7.0.txt
 
 file:data+7.0.txt
                 path = data+7.0.txt
                state = BUILT
-          created by   step:./work.py run -- '+7.0'
+          created by   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
             consumes   file:./
-            consumes   step:./work.py run -- '+7.0'
+            consumes   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+
+file:stderr+7.0.txt
+                path = stderr+7.0.txt
+               state = BUILT
+          created by   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+            consumes   file:./
+            consumes   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+
+file:stdout+7.0.txt
+                path = stdout+7.0.txt
+               state = BUILT
+          created by   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+            consumes   file:./
+            consumes   step:./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt

--- a/tests/cases/script_cases/expected_stdout.txt
+++ b/tests/cases/script_cases/expected_stdout.txt
@@ -4,10 +4,10 @@
    SUCCESS │ ./plan.py
      START │ ./work.py plan
    SUCCESS │ ./work.py plan
-     START │ ./work.py run -- '-5.0'
-   SUCCESS │ ./work.py run -- '-5.0'
-     START │ ./work.py run -- '+7.0'
-   SUCCESS │ ./work.py run -- '+7.0'
+     START │ ./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
+   SUCCESS │ ./work.py run -- '-5.0' > stdout-5.0.txt 2> stderr-5.0.txt
+     START │ ./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
+   SUCCESS │ ./work.py run -- '+7.0' > stdout+7.0.txt 2> stderr+7.0.txt
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz
      PHASE │ watch
   DIRECTOR │ Stopping workers.

--- a/tests/cases/script_cases/main.sh
+++ b/tests/cases/script_cases/main.sh
@@ -29,3 +29,7 @@ wait
 [[ -f work.py ]] || exit 1
 [[ -f data-5.0.txt ]] || exit 1
 [[ -f data+7.0.txt ]] || exit 1
+grep "Standard output for -5.0" stdout-5.0.txt
+grep "Standard output for +7.0" stdout+7.0.txt
+grep "Standard error for -5.0" stderr-5.0.txt
+grep "Standard error for +7.0" stderr+7.0.txt

--- a/tests/cases/script_cases/work.py
+++ b/tests/cases/script_cases/work.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import sys
+
 from helper import num_to_str
 
 from stepup.core.script import driver
@@ -16,12 +18,16 @@ def case_info(num):
     return {
         "out": f"data{num:+03.1f}.txt",
         "num": num,
+        "stdout": f"stdout{num:+03.1f}.txt",
+        "stderr": f"stderr{num:+03.1f}.txt",
     }
 
 
 def run(num, out):
     with open(out, "w") as fh:
         fh.write(f"{num_to_str(num)}\n")
+    print(f"Standard output for {num:+03.1f}")
+    print(f"Standard error for {num:+03.1f}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/cases/script_single/.gitignore
+++ b/tests/cases/script_single/.gitignore
@@ -2,3 +2,5 @@
 work/test.csv
 work/copy.csv
 current_*
+work/stdout.txt
+work/stderr.txt

--- a/tests/cases/script_single/expected_graph.txt
+++ b/tests/cases/script_single/expected_graph.txt
@@ -40,9 +40,11 @@ file:work/
             supplies   file:work/config.json
             supplies   file:work/copy.csv
             supplies   file:work/generate.py
+            supplies   file:work/stderr.txt
+            supplies   file:work/stdout.txt
             supplies   file:work/test.csv
             supplies   step:./generate.py plan --optional  # wd=work/
-            supplies   step:./generate.py run  # wd=work/
+            supplies   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
             supplies   step:cp -aT work/test.csv work/copy.csv
 
 file:work/generate.py
@@ -51,7 +53,7 @@ file:work/generate.py
           created by   step:./plan.py
             consumes   file:work/
             supplies   step:./generate.py plan --optional  # wd=work/
-            supplies   step:./generate.py run  # wd=work/
+            supplies   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
 
 step:./generate.py plan --optional  # wd=work/
              workdir = work/
@@ -61,7 +63,7 @@ step:./generate.py plan --optional  # wd=work/
             consumes   file:work/
             consumes   file:work/generate.py
              creates   file:work/config.json
-             creates   step:./generate.py run  # wd=work/
+             creates   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
 
 step:cp -aT work/test.csv work/copy.csv
              workdir = ./
@@ -77,9 +79,9 @@ step:cp -aT work/test.csv work/copy.csv
 file:work/test.csv
                 path = work/test.csv
                state = BUILT
-          created by   step:./generate.py run  # wd=work/
+          created by   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
             consumes   file:work/
-            consumes   step:./generate.py run  # wd=work/
+            consumes   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
             supplies   step:cp -aT work/test.csv work/copy.csv
 
 file:work/copy.csv
@@ -94,16 +96,34 @@ file:work/config.json
                state = STATIC
           created by   step:./generate.py plan --optional  # wd=work/
             consumes   file:work/
-            supplies   step:./generate.py run  # wd=work/
+            supplies   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
 
-step:./generate.py run  # wd=work/
+step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
              workdir = work/
-             command = ./generate.py run
+             command = ./generate.py run > stdout.txt 2> stderr.txt
                state = SUCCEEDED
            mandatory = IMPLIED
           created by   step:./generate.py plan --optional  # wd=work/
             consumes   file:work/
             consumes   file:work/config.json
             consumes   file:work/generate.py
+             creates   file:work/stderr.txt
+             creates   file:work/stdout.txt
              creates   file:work/test.csv
+            supplies   file:work/stderr.txt
+            supplies   file:work/stdout.txt
             supplies   file:work/test.csv
+
+file:work/stderr.txt
+                path = work/stderr.txt
+               state = BUILT
+          created by   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
+            consumes   file:work/
+            consumes   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
+
+file:work/stdout.txt
+                path = work/stdout.txt
+               state = BUILT
+          created by   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
+            consumes   file:work/
+            consumes   step:./generate.py run > stdout.txt 2> stderr.txt  # wd=work/

--- a/tests/cases/script_single/expected_stdout.txt
+++ b/tests/cases/script_single/expected_stdout.txt
@@ -4,8 +4,8 @@
    SUCCESS │ ./plan.py
      START │ ./generate.py plan --optional  # wd=work/
    SUCCESS │ ./generate.py plan --optional  # wd=work/
-     START │ ./generate.py run  # wd=work/
-   SUCCESS │ ./generate.py run  # wd=work/
+     START │ ./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
+   SUCCESS │ ./generate.py run > stdout.txt 2> stderr.txt  # wd=work/
      START │ cp -aT work/test.csv work/copy.csv
    SUCCESS │ cp -aT work/test.csv work/copy.csv
   WORKFLOW │ Dumped to .stepup/workflow.mpk.xz

--- a/tests/cases/script_single/main.sh
+++ b/tests/cases/script_single/main.sh
@@ -28,3 +28,5 @@ wait
 [[ -f work/generate.py ]] || exit 1
 [[ -f work/test.csv ]] || exit 1
 [[ -f work/copy.csv ]] || exit 1
+grep "Standard output" work/stdout.txt
+grep "Standard error" work/stderr.txt

--- a/tests/cases/script_single/work/generate.py
+++ b/tests/cases/script_single/work/generate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import json
+import sys
 
 from stepup.core.script import driver
 
@@ -10,6 +11,8 @@ def info():
         "static": "config.json",
         "inp": "config.json",
         "out": "test.csv",
+        "stdout": "stdout.txt",
+        "stderr": "stderr.txt",
     }
 
 
@@ -23,6 +26,8 @@ def run():
                 fh.write(f"foo,{value}\n")
             else:
                 fh.write(f"bar,{value}\n")
+    print("Standard output")
+    print("Standard error", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,78 @@
+# StepUp Core provides the basic framework for the StepUp build tool.
+# Copyright (C) 2024 Toon Verstraelen
+#
+# This file is part of StepUp Core.
+#
+# StepUp Core is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# StepUp Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Unit tests for stepup.core.script."""
+
+import pytest
+
+from stepup.core.script import _add_redirects, _get_optional_path, _get_path_list
+
+
+def test_add_redirects_both():
+    out_paths = ["aaa"]
+    assert _add_redirects("echo foo", out_paths, "out", "err") == "echo foo > out 2> err"
+    assert out_paths == ["aaa", "out", "err"]
+
+
+def test_add_redirects_none():
+    out_paths = ["aaa"]
+    assert _add_redirects("echo foo", out_paths, None, None) == "echo foo"
+    assert out_paths == ["aaa"]
+
+
+def test_add_redirects_out():
+    out_paths = ["aaa"]
+    assert _add_redirects("echo foo", out_paths, "out", None) == "echo foo > out"
+    assert out_paths == ["aaa", "out"]
+
+
+def test_add_redirects_err():
+    out_paths = ["aaa"]
+    assert _add_redirects("echo foo", out_paths, None, "err") == "echo foo 2> err"
+    assert out_paths == ["aaa", "err"]
+
+
+def test_add_redirects_combined():
+    out_paths = ["aaa"]
+    assert _add_redirects("echo foo", out_paths, "out", "__stdout__") == "echo foo &> out"
+    assert out_paths == ["aaa", "out"]
+
+
+def test_add_redirects_devnull():
+    out_paths = ["aaa"]
+    expected = "echo foo > /dev/null 2> /dev/null"
+    assert _add_redirects("echo foo", out_paths, "/dev/null", "/dev/null") == expected
+    assert out_paths == ["aaa"]
+
+
+def test_get_path_list():
+    info = {"inp": ["aa", "bb"], "out": "cc", "blub": 0}
+    assert _get_path_list("inp", info, "foo.py", "info") == ["aa", "bb"]
+    assert _get_path_list("out", info, "foo.py", "info") == ["cc"]
+    assert _get_path_list("vol", info, "foo.py", "info") == []
+    with pytest.raises(TypeError):
+        _get_path_list("blub", info, "foo.py", "info")
+
+
+def test_optional_path():
+    info = {"stdout": "lalala", "stderr": 3}
+    assert _get_optional_path("stdout", info, "bar.py", "info") == "lalala"
+    assert _get_optional_path("stdstd", info, "bar.py", "info") is None
+    with pytest.raises(TypeError):
+        _get_optional_path("stderr", info, "bar.py", "info")

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -50,13 +50,13 @@ def test_add_redirects_err():
 
 def test_add_redirects_combined():
     out_paths = ["aaa"]
-    assert _add_redirects("echo foo", out_paths, "out", "__stdout__") == "echo foo &> out"
+    assert _add_redirects("echo foo", out_paths, "out", "out") == "echo foo &> out"
     assert out_paths == ["aaa", "out"]
 
 
 def test_add_redirects_devnull():
     out_paths = ["aaa"]
-    expected = "echo foo > /dev/null 2> /dev/null"
+    expected = "echo foo &> /dev/null"
     assert _add_redirects("echo foo", out_paths, "/dev/null", "/dev/null") == expected
     assert out_paths == ["aaa"]
 


### PR DESCRIPTION
- Support stdout and stderr in dictionary returned by `info` or `case_info`.
- Split large function in stepup.core.driver.
- Add missing docstrings in stepup.core.driver.
- Add some unit tests for stepup.core.driver.
- Fix indented include in docs.
- Add stdout and stderr redirection to two test cases.
- Regenerate example outputs.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces support for standard output and error redirection in the script driver, refactors the `driver` function for better maintainability, adds missing docstrings, updates documentation to reflect the new features, and includes new and updated tests to ensure functionality.

- **New Features**:
    - Added support for standard output and error redirection in the script driver. The dictionary returned by the `info` or `case_info` functions can now include `stdout` and `stderr` items, which specify paths for redirecting standard output and error.
- **Enhancements**:
    - Refactored the `driver` function in `stepup.core.script` to split it into smaller, more manageable functions.
    - Added missing docstrings to various functions in `stepup.core.script` for better code documentation and readability.
- **Build**:
    - Updated `.pre-commit-config.yaml` to use newer versions of `ruff-pre-commit` and `check-jsonschema`.
- **Documentation**:
    - Updated documentation to include information about the new `stdout` and `stderr` fields in the `info` and `case_info` functions.
    - Fixed an indented include in the documentation.
    - Added examples and explanations for the new standard output and error redirection features in the getting started guides.
- **Tests**:
    - Added unit tests for the new standard output and error redirection features in `stepup.core.script`.
    - Updated existing test cases to include checks for standard output and error redirection.

<!-- Generated by sourcery-ai[bot]: end summary -->