### PR TITLE
Rudimentary macOS support

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,0 +1,44 @@
+# Simply check that something works on macOS
+name: smoke
+on:
+  push:
+    branches:
+      # Run tests for change on the main branch ...
+      - main
+    tags-ignore:
+      # ... but not for tags (avoids duplicate work) ...
+      - '**'
+    paths:
+      # ... and only if relevant files have changed.
+      - stepup/**
+      - pyproject.toml
+      - .github/workflows/pytest.yaml
+  pull_request:
+    # Run tests on pull requests ...
+    paths:
+      # ... only if relevant files have changed.
+      - stepup/**
+      - pyproject.toml
+      - .github/workflows/pytest.yaml
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.13']
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install oldest versions of supported dependencies
+        if: ${{ matrix.python-version == '3.11'}}
+        run: pip install -r .github/requirements-old.txt
+      - name: Install development version
+        run: pip install -e .
+      - name: Run a simple example
+        run: |
+          cd docs
+          STEPUP_DEBUG=1 STEPUP_SYNC_RPC_TIMEOUT=10 stepup boot -n 1.0

--- a/stepup/core/director.py
+++ b/stepup/core/director.py
@@ -182,7 +182,9 @@ def parse_args() -> argparse.Namespace:
 def interpret_num_workers(num_workers: Decimal) -> int:
     """Convert the command-line argument num-workers into an integer."""
     if num_workers.as_tuple().exponent < 0:
-        return int(len(os.sched_getaffinity(0)) * num_workers)
+        if hasattr(os, "sched_getaffinity"):
+            return int(len(os.sched_getaffinity(0)) * num_workers)
+        return int(os.cpu_count() * num_workers)
     return int(num_workers)
 
 

--- a/stepup/core/director.py
+++ b/stepup/core/director.py
@@ -48,7 +48,7 @@ from .scheduler import Scheduler
 from .startup import startup_from_db
 from .stepinfo import StepInfo
 from .utils import DBLock, check_plan, mynormpath
-from .watcher import Watcher
+from .watcher import WATCHER_AVAILABLE, Watcher
 from .workflow import Workflow
 
 __all__ = ("get_socket", "interpret_num_workers", "serve")
@@ -145,22 +145,23 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Explain for every step with recording info why it cannot be skipped.",
     )
-    parser.add_argument(
-        "--watch",
-        "-w",
-        default=False,
-        action="store_true",
-        help="Watch file changes after completing the run phase. "
-        "When not given, the director exists after completing the run phase.",
-    )
-    parser.add_argument(
-        "--watch-first",
-        "-W",
-        default=False,
-        action="store_true",
-        help="Exit watch phase and start the runner after the first file change. "
-        "This implies --watch.",
-    )
+    if WATCHER_AVAILABLE:
+        parser.add_argument(
+            "--watch",
+            "-w",
+            default=False,
+            action="store_true",
+            help="Watch file changes after completing the run phase. "
+            "When not given, the director exists after completing the run phase.",
+        )
+        parser.add_argument(
+            "--watch-first",
+            "-W",
+            default=False,
+            action="store_true",
+            help="Exit watch phase and start the runner after the first file change. "
+            "This implies --watch.",
+        )
     parser.add_argument(
         "--no-clean",
         dest="do_clean",
@@ -169,8 +170,12 @@ def parse_args() -> argparse.Namespace:
         help="Do not remove outdated output files.",
     )
     args = parser.parse_args()
-    if args.watch_first:
-        args.watch = True
+    if WATCHER_AVAILABLE:
+        if args.watch_first:
+            args.watch = True
+    else:
+        args.watch = False
+        args.watch_first = False
     return args
 
 

--- a/stepup/core/watcher.py
+++ b/stepup/core/watcher.py
@@ -20,9 +20,9 @@
 """Watch for file changes and update the workflow accordingly."""
 
 import asyncio
+import sys
 
 import attrs
-from asyncinotify import Inotify, Mask, Watch
 from path import Path
 
 from .asyncio import stoppable_iterator
@@ -32,7 +32,22 @@ from .reporter import ReporterClient
 from .utils import DBLock
 from .workflow import Workflow
 
-__all__ = ("Watcher",)
+WATCHER_AVAILABLE = sys.platform == "linux"
+if WATCHER_AVAILABLE:
+    from asyncinotify import Inotify, Mask, Watch
+else:
+
+    class Inotify:
+        pass
+
+    class Mask:
+        pass
+
+    class Watch:
+        pass
+
+
+__all__ = ("WATCHER_AVAILABLE", "Watcher")
 
 
 @attrs.define

--- a/stepup/core/watcher.py
+++ b/stepup/core/watcher.py
@@ -36,7 +36,7 @@ WATCHER_AVAILABLE = sys.platform == "linux"
 if WATCHER_AVAILABLE:
     from asyncinotify import Inotify, Mask, Watch
 else:
-
+    # Dummy classes for non-linux platforms to avoid type errors below.
     class Inotify:
         pass
 


### PR DESCRIPTION
## Summary by Sourcery

Enable rudimentary macOS support by conditionally stubbing file-watching capabilities on non-Linux platforms and adding a macOS smoke-test CI workflow

New Features:
- Introduce a platform flag to stub file-watching on non-Linux systems, enabling macOS compatibility
- Add a smoke-test GitHub Actions workflow to run basic StepUp commands on macOS

Enhancements:
- Guard watch and watch-first CLI flags and related logic on the availability of file-watching support

CI:
- Add a GitHub Actions workflow to smoke-test StepUp functionality on macOS