### PR TITLE
Fix uint64 inode bug

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,7 @@ Bugfix release: support large inodes in SQLite storage
 
 - Fixed a bug in the representation of large inodes in SQLite storage.
   SQLite works with signed 64-bit integers, but inodes can be unsigned 64-bit integers.
-  They are now converted back and forth to fit transparantely,
+  They are now converted back and forth to fit transparently,
   by wrapping too large numbers around to negative values.
   This change is backward compatible.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,15 @@ and this project adheres to [Effort-based Versioning](https://jacobtomlinson.dev
 
 ## [Unreleased][]
 
-(no changes yet)
+Bugfix release: support large inodes in SQLite storage
+
+### Fixed
+
+- Fixed a bug in the representation of large inodes in SQLite storage.
+  SQLite works with signed 64-bit integers, but inodes can be unsigned 64-bit integers.
+  They are now converted back and forth to fit transparantely,
+  by wrapping too large numbers around to negative values.
+  This change is backward compatible.
 
 ## [3.2.2][] - 2026-02-08 {: #v3.2.3 }
 

--- a/docs/run_example.py
+++ b/docs/run_example.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Run one example and amend (volatile) outputs."""
 
-import sqlite3
 import subprocess
 import sys
 
@@ -9,6 +8,7 @@ from path import Path
 
 from stepup.core.api import amend
 from stepup.core.file import FileState
+from stepup.core.sqlite3 import connect
 
 SQL = "SELECT label, state FROM node JOIN file ON node.i = file.node"
 
@@ -22,9 +22,7 @@ def main():
     root = Path(root)
     path_stepup = root / ".stepup/"
     path_graph = path_stepup / "graph.db"
-    con = sqlite3.Connection(
-        f"file:{path_graph}?mode=ro", uri=True, detect_types=sqlite3.PARSE_COLNAMES
-    )
+    con = connect(f"file:{path_graph}?mode=ro", uri=True)
     out = [path_stepup]
     vol = [path_graph]
     for path, state_i in con.execute(SQL):

--- a/docs/run_example.py
+++ b/docs/run_example.py
@@ -22,7 +22,9 @@ def main():
     root = Path(root)
     path_stepup = root / ".stepup/"
     path_graph = path_stepup / "graph.db"
-    con = sqlite3.Connection(f"file:{path_graph}?mode=ro", uri=True)
+    con = sqlite3.Connection(
+        f"file:{path_graph}?mode=ro", uri=True, detect_types=sqlite3.PARSE_COLNAMES
+    )
     out = [path_stepup]
     vol = [path_graph]
     for path, state_i in con.execute(SQL):

--- a/stepup/core/browse.py
+++ b/stepup/core/browse.py
@@ -275,8 +275,8 @@ class GraphServer(BaseHTTPRequestHandler):
             print("Loading database...")
             if self.con is not None:
                 self.con.close()
-            self.con = sqlite3.Connection(":memory:")
-            src = sqlite3.Connection(self.path_db)
+            self.con = sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES)
+            src = sqlite3.Connection(self.path_db, detect_types=sqlite3.PARSE_COLNAMES)
             try:
                 src.backup(self.con)
             finally:
@@ -415,7 +415,9 @@ class GraphServer(BaseHTTPRequestHandler):
 
         elif kind == "file":
             (state_i, digest, mode, mtime, size, inode) = self.con.execute(
-                "SELECT state, digest, mode, mtime, size, inode FROM file WHERE node = ?", (node_i,)
+                "SELECT state, digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM file "
+                "WHERE node = ?",
+                (node_i,),
             ).fetchone()
             state = FileState(state_i)
             yield f'<p><b>State:</b> <span class="{state.name.lower()}">{state.name}</span></p>'

--- a/stepup/core/browse.py
+++ b/stepup/core/browse.py
@@ -24,7 +24,6 @@ import contextlib
 import importlib.resources
 import os
 import pickle
-import sqlite3
 import stat
 import traceback
 from collections.abc import Iterator
@@ -37,6 +36,7 @@ from path import Path
 
 from .enums import FileState, Mandatory, StepState
 from .hash import fmt_digest
+from .sqlite3 import connect
 
 
 def browse_subcommand(subparser: argparse.ArgumentParser) -> callable:
@@ -275,8 +275,8 @@ class GraphServer(BaseHTTPRequestHandler):
             print("Loading database...")
             if self.con is not None:
                 self.con.close()
-            self.con = sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES)
-            src = sqlite3.Connection(self.path_db, detect_types=sqlite3.PARSE_COLNAMES)
+            self.con = connect(":memory:")
+            src = connect(self.path_db)
             try:
                 src.backup(self.con)
             finally:

--- a/stepup/core/cascade.py
+++ b/stepup/core/cascade.py
@@ -562,6 +562,7 @@ class Cascade:
         # While making this change, the enums were also made more intuitive.
         # Schema 2 became outdated due to the worker actions.
         # Schema 3 became outdated due to a change in step table (dirty field).
+        # TODO: In the next schema, use UINT64 with PARSE_DECLTYPES instead of PARSE_COLNAMES.
         return 4
 
     @classmethod

--- a/stepup/core/cascade.py
+++ b/stepup/core/cascade.py
@@ -562,7 +562,9 @@ class Cascade:
         # While making this change, the enums were also made more intuitive.
         # Schema 2 became outdated due to the worker actions.
         # Schema 3 became outdated due to a change in step table (dirty field).
-        # TODO: In the next schema, use UINT64 with PARSE_DECLTYPES instead of PARSE_COLNAMES.
+
+        # Delayed Schema updates, for version 5:
+        # - Use UINT64 with PARSE_DECLTYPES instead of PARSE_COLNAMES.
         return 4
 
     @classmethod

--- a/stepup/core/clean.py
+++ b/stepup/core/clean.py
@@ -175,7 +175,7 @@ def fmtnum(i: int):
 CREATE_INITIAL_PATHS = "CREATE TABLE temp.initial_path(path TEXT PRIMARY KEY) WITHOUT ROWID"
 
 SELECT_OUTPUTS = f"""
-SELECT label, file.state, orphan, digest, mode, mtime, size, inode FROM node
+SELECT label, file.state, orphan, digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM node
 JOIN all_consumer ON node.i = all_consumer.current
 JOIN file ON file.node = all_consumer.current
 WHERE file.state in

--- a/stepup/core/clean.py
+++ b/stepup/core/clean.py
@@ -29,7 +29,8 @@ from rich.console import Console
 from .cascade import DROP_CONSUMERS, INITIAL_CONSUMERS, RECURSE_CONSUMERS
 from .enums import FileState
 from .hash import FileHash
-from .utils import mynormpath, sqlite3_copy_in_memory, translate, translate_back
+from .sqlite3 import copy_db_in_memory
+from .utils import mynormpath, translate, translate_back
 
 
 def clean_subcommand(subparser: argparse.ArgumentParser) -> callable:
@@ -91,7 +92,7 @@ def clean_tool(args: argparse.Namespace):
     # Copy the database in memory and work on the copy.
     root = Path(os.getenv("STEPUP_ROOT", "."))
     path_db = root / ".stepup/graph.db"
-    with sqlite3_copy_in_memory(path_db) as con:
+    with copy_db_in_memory(path_db) as con:
         clean(con, tr_paths, args)
 
 

--- a/stepup/core/director.py
+++ b/stepup/core/director.py
@@ -258,7 +258,9 @@ async def serve(
     check_plan("plan.py")
 
     # Create basic components
-    con = sqlite3.connect(".stepup/graph.db", cached_statements=1024)
+    con = sqlite3.connect(
+        ".stepup/graph.db", cached_statements=1024, detect_types=sqlite3.PARSE_COLNAMES
+    )
     dblock = DBLock(con)
     workflow = Workflow(con)
     scheduler = Scheduler(workflow.job_queue, workflow.config_queue, workflow.job_queue_changed)

--- a/stepup/core/director.py
+++ b/stepup/core/director.py
@@ -24,7 +24,6 @@ import asyncio
 import logging
 import os
 import signal
-import sqlite3
 import sys
 import time
 import traceback
@@ -48,6 +47,7 @@ from .reporter import ReporterClient
 from .rpc import allow_rpc, serve_socket_rpc
 from .runner import Runner
 from .scheduler import Scheduler
+from .sqlite3 import connect
 from .startup import startup_from_db
 from .step import Step
 from .stepinfo import StepInfo
@@ -258,9 +258,7 @@ async def serve(
     check_plan("plan.py")
 
     # Create basic components
-    con = sqlite3.connect(
-        ".stepup/graph.db", cached_statements=1024, detect_types=sqlite3.PARSE_COLNAMES
-    )
+    con = connect(".stepup/graph.db")
     dblock = DBLock(con)
     workflow = Workflow(con)
     scheduler = Scheduler(workflow.job_queue, workflow.config_queue, workflow.job_queue_changed)

--- a/stepup/core/file.py
+++ b/stepup/core/file.py
@@ -246,7 +246,6 @@ class File(Node):
     def get_hash(self) -> FileHash:
         sql = "SELECT digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM file WHERE node = ?"
         row = self.con.execute(sql, (self.i,)).fetchone()
-        print(row)
         return FileHash(*row)
 
     #

--- a/stepup/core/file.py
+++ b/stepup/core/file.py
@@ -20,8 +20,9 @@
 """A `File` is StepUp's node for an input or output file of a step."""
 
 import logging
+import sqlite3
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import attrs
 from path import Path
@@ -65,6 +66,31 @@ CREATE INDEX IF NOT EXISTS file_state ON file(state);
 """
 
 
+class UInt64(int):
+    """A wrapper to tell SQLite this int should be treated as an unsigned 64-bit value."""
+
+    MAX_SIGNED_64 = 2**63 - 1
+    MAX_WRAPAROUND_64 = 2**64
+    MAX_UNSIGNED_64 = MAX_WRAPAROUND_64 - 1
+
+    @staticmethod
+    def adapt(val: Self) -> int:
+        if not (0 <= val <= UInt64.MAX_UNSIGNED_64):
+            raise ValueError(f"Value {val} out of UINT64 range")
+        return val - UInt64.MAX_WRAPAROUND_64 if val > UInt64.MAX_SIGNED_64 else val
+
+    @staticmethod
+    def convert(val: int) -> Self:
+        val = int(val)
+        if val < 0:
+            val += UInt64.MAX_WRAPAROUND_64
+        return UInt64(val)
+
+
+sqlite3.register_adapter(UInt64, UInt64.adapt)
+sqlite3.register_converter("UINT64", UInt64.convert)
+
+
 @attrs.define
 class File(Node):
     """A concrete file on the filesystem (may also be a directory)."""
@@ -102,7 +128,10 @@ class File(Node):
         # If the file was previously BUILT or OUTDATED, and created again as AWAITED,
         # it should copy that state
         if state == FileState.AWAITED:
-            sql = "SELECT state, digest, mode, mtime, size, inode FROM file WHERE node = ?"
+            sql = (
+                "SELECT state, digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM file "
+                "WHERE node = ?"
+            )
             row = self.con.execute(sql, (self.i,)).fetchone()
             if row is not None and row[0] in (FileState.BUILT.value, FileState.OUTDATED.value):
                 state = FileState(row[0])
@@ -121,7 +150,7 @@ class File(Node):
                 "mode": mode,
                 "mtime": mtime,
                 "size": size,
-                "inode": inode,
+                "inode": UInt64(inode),
             },
         )
         # If the state is BUILT, mark it as OUTDATED to force a rebuild.
@@ -215,8 +244,9 @@ class File(Node):
         self.con.execute(sql, (state.value, self.i))
 
     def get_hash(self) -> FileHash:
-        sql = "SELECT digest, mode, mtime, size, inode FROM file WHERE node = ?"
+        sql = "SELECT digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM file WHERE node = ?"
         row = self.con.execute(sql, (self.i,)).fetchone()
+        print(row)
         return FileHash(*row)
 
     #

--- a/stepup/core/file.py
+++ b/stepup/core/file.py
@@ -20,9 +20,8 @@
 """A `File` is StepUp's node for an input or output file of a step."""
 
 import logging
-import sqlite3
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 
 import attrs
 from path import Path
@@ -30,6 +29,7 @@ from path import Path
 from .cascade import Node
 from .enums import DirWatch, FileState
 from .hash import FileHash
+from .sqlite3 import UInt64
 from .utils import format_digest
 
 if TYPE_CHECKING:
@@ -64,31 +64,6 @@ CREATE TABLE IF NOT EXISTS file (
 ) WITHOUT ROWID;
 CREATE INDEX IF NOT EXISTS file_state ON file(state);
 """
-
-
-class UInt64(int):
-    """A wrapper to tell SQLite this int should be treated as an unsigned 64-bit value."""
-
-    MAX_SIGNED_64 = 2**63 - 1
-    MAX_WRAPAROUND_64 = 2**64
-    MAX_UNSIGNED_64 = MAX_WRAPAROUND_64 - 1
-
-    @staticmethod
-    def adapt(val: Self) -> int:
-        if not (0 <= val <= UInt64.MAX_UNSIGNED_64):
-            raise ValueError(f"Value {val} out of UINT64 range")
-        return val - UInt64.MAX_WRAPAROUND_64 if val > UInt64.MAX_SIGNED_64 else val
-
-    @staticmethod
-    def convert(val: int) -> Self:
-        val = int(val)
-        if val < 0:
-            val += UInt64.MAX_WRAPAROUND_64
-        return UInt64(val)
-
-
-sqlite3.register_adapter(UInt64, UInt64.adapt)
-sqlite3.register_converter("UINT64", UInt64.convert)
 
 
 @attrs.define

--- a/stepup/core/sqlite3.py
+++ b/stepup/core/sqlite3.py
@@ -1,0 +1,82 @@
+# StepUp Core provides the basic framework for the StepUp build tool.
+# Copyright 2024-2026 Toon Verstraelen
+#
+# This file is part of StepUp Core.
+#
+# StepUp Core is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# StepUp Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Wrapper for SQLite3 functionality."""
+
+import contextlib
+import sqlite3
+from collections.abc import Iterator
+from typing import Self
+
+__all__ = ("UInt64", "connect", "copy_db_in_memory")
+
+
+class UInt64(int):
+    """A wrapper to tell SQLite this int should be treated as an unsigned 64-bit value."""
+
+    MAX_SIGNED_64 = 2**63 - 1
+    MAX_WRAPAROUND_64 = 2**64
+    MAX_UNSIGNED_64 = MAX_WRAPAROUND_64 - 1
+
+    @staticmethod
+    def adapt(val: Self) -> int:
+        if not (0 <= val <= UInt64.MAX_UNSIGNED_64):
+            raise ValueError(f"Value {val} out of UINT64 range")
+        return val - UInt64.MAX_WRAPAROUND_64 if val > UInt64.MAX_SIGNED_64 else val
+
+    @staticmethod
+    def convert(val: int) -> Self:
+        val = int(val)
+        if val < 0:
+            val += UInt64.MAX_WRAPAROUND_64
+        return UInt64(val)
+
+
+sqlite3.register_adapter(UInt64, UInt64.adapt)
+sqlite3.register_converter("UINT64", UInt64.convert)
+
+
+def connect(path: str, **kwargs) -> sqlite3.Connection:
+    """Connect to a SQLite database, with the appropriate settings for StepUp.
+
+    The following deviations from the default settings are used:
+
+    - Types can be detected from column names,
+      which allows us to use the custom UINT64 type for file inodes.
+    - The `cached_statements` parameter is set to a large value to improve
+      performance when executing many similar statements.
+    """
+    my_kwargs = {"cached_statements": 1024, "detect_types": sqlite3.PARSE_COLNAMES}
+    my_kwargs.update(kwargs)
+    return sqlite3.connect(path, **my_kwargs)
+
+
+@contextlib.contextmanager
+def copy_db_in_memory(path_db) -> Iterator[sqlite3.Connection]:
+    """Copy an SQLite database into memory and yield the connection."""
+    dst = connect(":memory:")
+    try:
+        src = connect(path_db)
+        try:
+            src.backup(dst)
+        finally:
+            src.close()
+        yield dst
+    finally:
+        dst.close()

--- a/stepup/core/sqlite3.py
+++ b/stepup/core/sqlite3.py
@@ -41,7 +41,7 @@ class UInt64(int):
         return val - UInt64.MAX_WRAPAROUND_64 if val > UInt64.MAX_SIGNED_64 else val
 
     @staticmethod
-    def convert(val: int) -> Self:
+    def convert(val: bytes) -> Self:
         val = int(val)
         if val < 0:
             val += UInt64.MAX_WRAPAROUND_64

--- a/stepup/core/sqlite3.py
+++ b/stepup/core/sqlite3.py
@@ -20,6 +20,7 @@
 """Wrapper for SQLite3 functionality."""
 
 import contextlib
+import os
 import sqlite3
 from collections.abc import Iterator
 from typing import Self
@@ -52,7 +53,7 @@ sqlite3.register_adapter(UInt64, UInt64.adapt)
 sqlite3.register_converter("UINT64", UInt64.convert)
 
 
-def connect(path: str, **kwargs) -> sqlite3.Connection:
+def connect(path: str | os.PathLike[str], **kwargs) -> sqlite3.Connection:
     """Connect to a SQLite database, with the appropriate settings for StepUp.
 
     The following deviations from the default settings are used:

--- a/stepup/core/startup.py
+++ b/stepup/core/startup.py
@@ -124,7 +124,7 @@ async def scan_file_changes(
 ) -> tuple[set[str], set[str]]:
     """Check all files in the workflow for changes."""
     sql = (
-        "SELECT label, state, digest, mode, mtime, size, inode "
+        "SELECT label, state, digest, mode, mtime, size, inode AS 'inode [UINT64]' "
         "FROM node JOIN file ON node.i = file.node AND state NOT IN (?, ?) AND NOT orphan"
     )
     data = (FileState.AWAITED.value, FileState.VOLATILE.value)

--- a/stepup/core/step.py
+++ b/stepup/core/step.py
@@ -731,7 +731,7 @@ class Step(Node):
         sql = (
             "SELECT node.label, node.orphan, file.state, "
             "EXISTS (SELECT 1 FROM amended_dep WHERE amended_dep.i = dep.i), "
-            "file.digest, file.mode, file.mtime, file.size, file.inode "
+            "file.digest, file.mode, file.mtime, file.size, file.inode AS 'inode [UINT64]' "
             "FROM node JOIN dependency AS dep ON node.i = dep.supplier "
             "JOIN file ON file.node = node.i "
             "WHERE dep.consumer = ?"

--- a/stepup/core/step.py
+++ b/stepup/core/step.py
@@ -558,7 +558,7 @@ class Step(Node):
             fields.append("state")
             join_file = True
         if yield_hash:
-            fields.extend(["digest", "mode", "mtime", "size", "inode"])
+            fields.extend(["digest", "mode", "mtime", "size", "inode AS 'inode [UINT64]'"])
             join_file = True
         if yield_orphan:
             fields.append("orphan")

--- a/stepup/core/utils.py
+++ b/stepup/core/utils.py
@@ -20,7 +20,6 @@
 """Small utilities used throughout."""
 
 import asyncio
-import contextlib
 import logging
 import os
 import re
@@ -28,7 +27,7 @@ import shlex
 import sqlite3
 import string
 import sys
-from collections.abc import Collection, Iterator
+from collections.abc import Collection
 
 import attrs
 from path import Path
@@ -429,18 +428,3 @@ def string_to_bool(v: str | bool) -> bool:
             return False
         raise ValueError(f"Cannot interpret '{v}' as a boolean value.")
     raise TypeError(f"Expected a boolean value or string. Got {type(v).__name__}")
-
-
-@contextlib.contextmanager
-def sqlite3_copy_in_memory(path_db) -> Iterator[sqlite3.Connection]:
-    """Copy an SQLite database into memory and yield the connection."""
-    dst = sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES)
-    try:
-        src = sqlite3.Connection(path_db, detect_types=sqlite3.PARSE_COLNAMES)
-        try:
-            src.backup(dst)
-        finally:
-            src.close()
-        yield dst
-    finally:
-        dst.close()

--- a/stepup/core/utils.py
+++ b/stepup/core/utils.py
@@ -434,9 +434,9 @@ def string_to_bool(v: str | bool) -> bool:
 @contextlib.contextmanager
 def sqlite3_copy_in_memory(path_db) -> Iterator[sqlite3.Connection]:
     """Copy an SQLite database into memory and yield the connection."""
-    dst = sqlite3.Connection(":memory:")
+    dst = sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES)
     try:
-        src = sqlite3.Connection(path_db)
+        src = sqlite3.Connection(path_db, detect_types=sqlite3.PARSE_COLNAMES)
         try:
             src.backup(dst)
         finally:

--- a/stepup/core/workflow.py
+++ b/stepup/core/workflow.py
@@ -36,7 +36,7 @@ from .cascade import Cascade, Node
 from .deferred_glob import DeferredGlob
 from .enums import FileState, Mandatory, StepState
 from .exceptions import GraphError
-from .file import File
+from .file import File, UInt64
 from .hash import FileHash, fmt_digest
 from .nglob import NGlobMulti, convert_nglob_to_regex, iter_wildcard_names
 from .step import Step
@@ -568,7 +568,8 @@ class Workflow(Cascade):
             sql = "INSERT INTO temp.missing VALUES (?)"
             self.con.executemany(sql, ((file.i,) for file in deferred))
             sql = (
-                "SELECT label, digest, mtime, mode, size, inode FROM temp.missing "
+                "SELECT label, digest, mtime, mode, size, inode AS 'inode [UINT64]' "
+                "FROM temp.missing "
                 "JOIN node ON node.i = temp.missing.node "
                 "JOIN file ON file.node = temp.missing.node"
             )
@@ -597,7 +598,7 @@ class Workflow(Cascade):
             self.con.execute("CREATE TABLE temp.paths(path TEXT PRIMARY KEY)")
             self.con.executemany("INSERT INTO temp.paths VALUES (?)", ((path,) for path in paths))
             sql = (
-                "SELECT label, digest, mode, mtime, size, inode FROM node "
+                "SELECT label, digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM node "
                 "JOIN file ON file.node = node.i JOIN temp.paths ON label = temp.paths.path"
             )
             return [
@@ -735,7 +736,7 @@ class Workflow(Cascade):
             "UPDATE file SET state = ?, digest = ?, mode = ?, mtime = ?, size = ?, inode = ? "
             "WHERE node = ?",
             (
-                (state.value, fh.digest, fh.mode, fh.mtime, fh.size, fh.inode, i)
+                (state.value, fh.digest, fh.mode, fh.mtime, fh.size, UInt64(fh.inode), i)
                 for i, state, fh in new_states_hashes
             ),
         )
@@ -1141,7 +1142,7 @@ class Workflow(Cascade):
                     file.orphan()
         # Delete outputs of steps that are no longer mandatory.
         cur = self.con.execute(
-            "SELECT label, digest, mode, mtime, size, inode FROM file "
+            "SELECT label, digest, mode, mtime, size, inode AS 'inode [UINT64]' FROM file "
             "JOIN node ON node.i = file.node "
             "JOIN dependency ON node.i = consumer "
             "JOIN step ON step.node = supplier "

--- a/stepup/core/workflow.py
+++ b/stepup/core/workflow.py
@@ -36,9 +36,10 @@ from .cascade import Cascade, Node
 from .deferred_glob import DeferredGlob
 from .enums import FileState, Mandatory, StepState
 from .exceptions import GraphError
-from .file import File, UInt64
+from .file import File
 from .hash import FileHash, fmt_digest
 from .nglob import NGlobMulti, convert_nglob_to_regex, iter_wildcard_names
+from .sqlite3 import UInt64
 from .step import Step
 from .utils import myparent, string_to_bool
 

--- a/stepup/core/workflow.py
+++ b/stepup/core/workflow.py
@@ -569,14 +569,14 @@ class Workflow(Cascade):
             sql = "INSERT INTO temp.missing VALUES (?)"
             self.con.executemany(sql, ((file.i,) for file in deferred))
             sql = (
-                "SELECT label, digest, mtime, mode, size, inode AS 'inode [UINT64]' "
+                "SELECT label, digest, mode, mtime, size, inode AS 'inode [UINT64]' "
                 "FROM temp.missing "
                 "JOIN node ON node.i = temp.missing.node "
                 "JOIN file ON file.node = temp.missing.node"
             )
             return [
-                (path, FileHash(digest, mtime, mode, size, inode))
-                for path, digest, mtime, mode, size, inode in self.con.execute(sql)
+                (path, FileHash(digest, mode, mtime, size, inode))
+                for path, digest, mode, mtime, size, inode in self.con.execute(sql)
             ]
         finally:
             self.con.execute("DROP TABLE IF EXISTS temp.missing")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def declare_static(workflow, creator, paths):
 @pytest.fixture
 def wfs() -> Iterator[Workflow]:
     """A workflow from scratch, no plan.py"""
-    workflow = Workflow(sqlite3.Connection(":memory:"))
+    workflow = Workflow(sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES))
     declare_static(workflow, workflow.root, ["./"])
     yield workflow
     workflow.check_consistency()
@@ -118,7 +118,7 @@ def wfs() -> Iterator[Workflow]:
 @pytest.fixture
 def wfp() -> Iterator[Workflow]:
     """A workflow with a boots step plan.py"""
-    workflow = Workflow(sqlite3.Connection(":memory:"))
+    workflow = Workflow(sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES))
     with workflow.con:
         # Prepare the basic workflow with a plan script.
         root = workflow.root

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ import asyncio
 import contextlib
 import hashlib
 import os
-import sqlite3
 import stat
 from collections.abc import AsyncGenerator, Iterator
 
@@ -37,6 +36,7 @@ from stepup.core.file import File
 from stepup.core.hash import FileHash
 from stepup.core.reporter import ReporterClient
 from stepup.core.rpc import AsyncRPCClient
+from stepup.core.sqlite3 import connect
 from stepup.core.step import Step
 from stepup.core.workflow import Workflow
 
@@ -109,7 +109,7 @@ def declare_static(workflow, creator, paths):
 @pytest.fixture
 def wfs() -> Iterator[Workflow]:
     """A workflow from scratch, no plan.py"""
-    workflow = Workflow(sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES))
+    workflow = Workflow(connect(":memory:"))
     declare_static(workflow, workflow.root, ["./"])
     yield workflow
     workflow.check_consistency()
@@ -118,7 +118,7 @@ def wfs() -> Iterator[Workflow]:
 @pytest.fixture
 def wfp() -> Iterator[Workflow]:
     """A workflow with a boots step plan.py"""
-    workflow = Workflow(sqlite3.Connection(":memory:", detect_types=sqlite3.PARSE_COLNAMES))
+    workflow = Workflow(connect(":memory:"))
     with workflow.con:
         # Prepare the basic workflow with a plan script.
         root = workflow.root

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -19,6 +19,7 @@
 # --
 """Unit tests for stepup.core.workflow."""
 
+import hashlib
 from collections import Counter
 
 import pytest
@@ -2493,3 +2494,17 @@ def test_clean_stepup_root_parents(wfs: Workflow):
     assert wfs.find(File, "../../") is None
     assert wfs.find(File, "../../../") is None
     assert wfs.find(File, "../foo.txt").get_state() == FileState.STATIC
+
+
+def test_large_inode(wfp: Workflow):
+    plan = wfp.find(Step, "./plan.py")
+    large_inode = 0x8000000000000001
+    wfp.declare_missing(plan, ["foo.txt"])
+    wfp.update_file_hashes(
+        [("foo.txt", FileHash(hashlib.blake2b(b"foo").digest(), 0o644, 1.0, 10, large_inode))],
+        "confirmed",
+    )
+    foo = wfp.find(File, "foo.txt")
+    hash_info = foo.get_hash()
+    assert hash_info is not None
+    assert hash_info.inode == large_inode


### PR DESCRIPTION
This change fixes the bug that very large inode values cannot be stored in the StepUp's SQLite database. This fix does not change the database schema. Unsigned integers are cast into signed ones (and back) without data loss.